### PR TITLE
style(#6): add clang-format, cmake-format, cmakelintrc and format the codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,29 @@
+---
+# cutils C/C++ formatting (issue #6).
+# Enforced via `clang-format -i` and by editors (LazyVim/conform.nvim runs
+# clang-format on save for c/cpp filetypes).
+BasedOnStyle: LLVM
+Language: Cpp
+IndentWidth: 2
+TabWidth: 2
+UseTab: Never
+ColumnLimit: 100
+
+# `if (x)` -- space after the control keyword, but NO space inside parens.
+# Function calls/declarations keep no space before the paren: `set(...)`.
+SpaceBeforeParens: ControlStatements
+SpacesInParens: Never
+
+# Opening brace on the same line for everything (functions + control blocks).
+BreakBeforeBraces: Attach
+
+# When a declaration/call wraps: one parameter per line, aligned to the first.
+AlignAfterOpenBracket: true            # true == Align
+BinPackParameters: OnePerLine
+BinPackArguments: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllArgumentsOnNextLine: true
+
+# Pointer asterisk on the right of the type: `state_t *p`, `void *ctx`.
+PointerAlignment: Right
+DerivePointerAlignment: false

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,19 @@
+# cutils CMake formatting (issue #6).
+# Enforced via `cmake-format -i` and by editors (LazyVim/conform.nvim with the
+# cmake = { "cmake_format" } formatters_by_ft mapping runs cmake-format on save
+# for the cmake filetype). cmake-format auto-discovers this file from the repo root.
+format:
+  line_width: 100
+  tab_size: 2
+  use_tabchars: false
+  # No space before the opening paren for ANY command -- control (if/foreach/
+  # endif) or function (set/message/option). Keeps `endif()`, `foreach()`,
+  # `set(...)` tight. cmake-format strips spaces *inside* parens by default,
+  # so `set( X )` -> `set(X)`.
+  separate_ctrl_name_with_space: false
+  separate_fn_name_with_space: false
+  dangle_parens: false
+  command_case: canonical
+  keyword_case: unchanged
+  enable_sort: true
+  autosort: false

--- a/.cmakelintrc
+++ b/.cmakelintrc
@@ -1,0 +1,23 @@
+# cutils CMake lint config (issue #6).
+# cmakelint (the standalone linter) reads this file from the repo root.
+# It is separate from .cmake-format.yaml (the formatter config) -- the two
+# tools do not share config, so they are kept in sync manually here.
+
+# Line length: the formatter (.cmake-format.yaml) targets 100 cols, but a few
+# legitimate long lines exist (e.g. unbreakable string literals that were
+# split into adjacent CMake string segments to stay under ~110). 120 gives
+# headroom without being permissive. cmakelint's default is 80.
+linelength=120
+
+# Disable the whitespace/indent check. cmake-format is the authority on
+# indentation; cmakelint's indent check expects multiples of 2 spaces and
+# conflicts with cmake-format's continuation-line alignment (e.g. args
+# aligned to the first argument of a wrapped command). Letting cmake-format
+# own indentation avoids the spurious "Weird indentation; use 2 spaces"
+# diagnostics on legitimately-formatted continuation lines.
+#
+# Also disable readability/wonkycase (mixed-case command names). CMake's own
+# module-provided commands are genuinely mixed-case by upstream design --
+# e.g. FetchContent_Declare, FetchContent_MakeAvailable -- and flagging them
+# is a false positive we cannot fix without abandoning FetchContent.
+filter=-whitespace/indent,-readability/wonkycase

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,8 @@ file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)
 if(EXISTS "${LOC_PATH}")
   message(
     FATAL_ERROR
-      "You cannot build in a source directory (or any directory with a CMakeLists.txt file). Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles."
-  )
+      "You cannot build in a source directory (or any directory with a CMakeLists.txt file). "
+      "Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles.")
 endif()
 
 # Only do these if this is the main project, and not if it is included through add_subdirectory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,43 +1,52 @@
-cmake_minimum_required( VERSION 3.14 )
-project( cutils VERSION 0.0.1 LANGUAGES C )
+cmake_minimum_required(VERSION 3.14)
+project(
+  cutils
+  VERSION 0.0.1
+  LANGUAGES C)
 
 find_package(Git QUIET)
-if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.gitmodules")
-  # Update submodules as needed (only when this branch actually declares any).
-  # master has no submodules after the googletest -> FetchContent migration
-  # (issue #4); other branches that still carry extern/FreeRTOS-Kernel keep a
-  # .gitmodules and this step runs for them.
+if(GIT_FOUND
+   AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git"
+   AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.gitmodules")
+  # Update submodules as needed (only when this branch actually declares any). master has no
+  # submodules after the googletest -> FetchContent migration (issue #4); other branches that still
+  # carry extern/FreeRTOS-Kernel keep a .gitmodules and this step runs for them.
   option(GIT_SUBMODULE "Check submodules during build" ON)
   if(GIT_SUBMODULE)
     message(STATUS "Submodule update")
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    RESULT_VARIABLE GIT_SUBMOD_RESULT)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      RESULT_VARIABLE GIT_SUBMOD_RESULT)
     if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-      message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+      message(
+        FATAL_ERROR
+          "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules"
+      )
     endif()
   endif()
 endif()
 
-### Require out-of-source builds
+# Require out-of-source builds
 file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)
 if(EXISTS "${LOC_PATH}")
-  message(FATAL_ERROR "You cannot build in a source directory (or any directory with a CMakeLists.txt file). Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles.")
+  message(
+    FATAL_ERROR
+      "You cannot build in a source directory (or any directory with a CMakeLists.txt file). Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles."
+  )
 endif()
 
 # Only do these if this is the main project, and not if it is included through add_subdirectory
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-  # Optionally set things like CMAKE_CXX_STANDARD, CMAKE_POSITION_INDEPENDENT_CODE here
-  # Let's ensure -std=c++xx instead of -std=g++xx
+  # Optionally set things like CMAKE_CXX_STANDARD, CMAKE_POSITION_INDEPENDENT_CODE here Let's ensure
+  # -std=c++xx instead of -std=g++xx
   set(CMAKE_CXX_EXTENSIONS OFF)
 
   # Let's nicely support folders in IDE's
   set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-  # Testing only available if this is the main app
-  # Note this needs to be done in the main CMakeLists
-  # since it calls enable_testing, which must be in the
-  # main CMakeLists.
+  # Testing only available if this is the main app Note this needs to be done in the main CMakeLists
+  # since it calls enable_testing, which must be in the main CMakeLists.
   include(CTest)
 
   # Docs only available if this is the main app
@@ -57,12 +66,12 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Version.h.in"
 set(API_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/inc" "${CMAKE_CURRENT_BINARY_DIR}/inc/")
 add_subdirectory(src)
 
-if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME ) AND BUILD_TESTING)
-  ### Tests
-option(PACKAGE_TESTS "Build the tests" ON)
-if(PACKAGE_TESTS)
-  enable_testing()
-  include(GoogleTest)
-  add_subdirectory(tests)
-endif()
+if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME) AND BUILD_TESTING)
+  # Tests
+  option(PACKAGE_TESTS "Build the tests" ON)
+  if(PACKAGE_TESTS)
+    enable_testing()
+    include(GoogleTest)
+    add_subdirectory(tests)
+  endif()
 endif()

--- a/cmake/BuildType.cmake
+++ b/cmake/BuildType.cmake
@@ -6,9 +6,10 @@ endif()
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
-  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
-      STRING "Choose the type of build." FORCE)
+  set(CMAKE_BUILD_TYPE
+      "${default_build_type}"
+      CACHE STRING "Choose the type of build." FORCE)
   # Set the possible values of build type for cmake-gui
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-               "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel"
+                                               "RelWithDebInfo")
 endif()

--- a/cmake/TestUtil.cmake
+++ b/cmake/TestUtil.cmake
@@ -1,25 +1,26 @@
 macro(package_add_test TESTNAME)
   # create an exectuable in which the tests will be stored
   add_executable(${TESTNAME} ${ARGN})
-  # link the Google test infrastructure, mocking library, and a default main fuction to
-  # the test executable.  Remove g_test_main if writing your own main function.
+  # link the Google test infrastructure, mocking library, and a default main fuction to the test
+  # executable.  Remove g_test_main if writing your own main function.
   target_link_libraries(${TESTNAME} gtest gmock gtest_main)
-  # gtest_discover_tests replaces gtest_add_tests,
-  # see https://cmake.org/cmake/help/v3.10/module/GoogleTest.html for more options to pass to it
-  gtest_discover_tests(${TESTNAME}
-                       # set a working directory so your project root so that you can find test data via paths relative to the project root
-                       WORKING_DIRECTORY ${PROJECT_DIR}
-                       PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}"
-                       )
+  # gtest_discover_tests replaces gtest_add_tests, see
+  # https://cmake.org/cmake/help/v3.10/module/GoogleTest.html for more options to pass to it
+  gtest_discover_tests(
+    ${TESTNAME}
+    # set a working directory so your project root so that you can find test data via paths relative
+    # to the project root
+    WORKING_DIRECTORY ${PROJECT_DIR}
+    PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}")
   set_target_properties(${TESTNAME} PROPERTIES FOLDER tests)
 endmacro()
 
 macro(package_add_test_with_libraries TESTNAME FILES LIBRARIES TEST_WORKING_DIRECTORY)
   add_executable(${TESTNAME} ${FILES})
   target_link_libraries(${TESTNAME} gtest gmock gtest_main ${LIBRARIES})
-  gtest_discover_tests(${TESTNAME}
-                       WORKING_DIRECTORY ${TEST_WORKING_DIRECTORY}
-                       PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${TEST_WORKING_DIRECTORY}"
-                       )
+  gtest_discover_tests(
+    ${TESTNAME}
+    WORKING_DIRECTORY ${TEST_WORKING_DIRECTORY}
+    PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${TEST_WORKING_DIRECTORY}")
   set_target_properties(${TESTNAME} PROPERTIES FOLDER tests)
 endmacro()

--- a/inc/cutils/accumulator.h
+++ b/inc/cutils/accumulator.h
@@ -24,20 +24,18 @@
 
 #pragma once
 
-#include <cutils/types.h>
 #include <cutils/logger.h>
-#include <string.h>
+#include <cutils/types.h>
 #include <inttypes.h>
+#include <string.h>
 
-typedef struct
-{
+typedef struct {
   uint8_t *buf;
   uint32_t total_buffer_size;
   uint32_t in, out;
 } accumulator_t;
 
-typedef struct
-{
+typedef struct {
   accumulator_t *acc;
   uint8_t *buf;
   uint32_t buf_size;
@@ -45,49 +43,46 @@ typedef struct
 
 typedef void *accumulator_h;
 
-#define ACCUMULATOR_STORE(name)   accumulator_store_##name
+#define ACCUMULATOR_STORE(name) accumulator_store_##name
 #define ACCUMULATOR_STORE_T(name) accumulator_store_##name##_t
-#define ACCUMULATOR_STORE_DECL(name, size_in_bytes)\
-typedef struct {\
-  accumulator_t acc;\
-  uint8_t buffer[size_in_bytes];\
-}ACCUMULATOR_STORE_T(name)
-#define ACCUMULATOR_STORE_DEF(name)\
-ACCUMULATOR_STORE_T(name) ACCUMULATOR_STORE(name) __attribute__((section(".bss.noinit")))
+#define ACCUMULATOR_STORE_DECL(name, size_in_bytes)                                                \
+  typedef struct {                                                                                 \
+    accumulator_t acc;                                                                             \
+    uint8_t buffer[size_in_bytes];                                                                 \
+  } ACCUMULATOR_STORE_T(name)
+#define ACCUMULATOR_STORE_DEF(name)                                                                \
+  ACCUMULATOR_STORE_T(name) ACCUMULATOR_STORE(name) __attribute__((section(".bss.noinit")))
 
-#define ACCUMULATOR_CREATE_PARAMS_INIT(params, name)\
-(params).acc = &ACCUMULATOR_STORE(name).acc;\
-(params).buf = ACCUMULATOR_STORE(name).buffer;\
-(params).buf_size = sizeof(ACCUMULATOR_STORE(name).buffer)
-
+#define ACCUMULATOR_CREATE_PARAMS_INIT(params, name)                                               \
+  (params).acc = &ACCUMULATOR_STORE(name).acc;                                                     \
+  (params).buf = ACCUMULATOR_STORE(name).buffer;                                                   \
+  (params).buf_size = sizeof(ACCUMULATOR_STORE(name).buffer)
 
 typedef uint32_t accumulator_iterator_t;
 
-static inline accumulator_iterator_t accumulator_iterator_init(accumulator_h accumulator)
-{
-  return ((accumulator_t *) accumulator)->out;
+static inline accumulator_iterator_t accumulator_iterator_init(accumulator_h accumulator) {
+  return ((accumulator_t *)accumulator)->out;
 }
 
-static inline bool accumulator_iterator_valid(accumulator_h accumulator, accumulator_iterator_t iterator)
-{
-  accumulator_t *p_acc = (accumulator_t *) accumulator;
+static inline bool accumulator_iterator_valid(accumulator_h accumulator,
+                                              accumulator_iterator_t iterator) {
+  accumulator_t *p_acc = (accumulator_t *)accumulator;
   return ((p_acc->in != p_acc->out) && iterator != p_acc->in);
 }
 
-static inline bool accumulator_iterator_next(accumulator_h accumulator, accumulator_iterator_t *iterator)
-{
-  accumulator_t *p_acc = (accumulator_t *) accumulator;
+static inline bool accumulator_iterator_next(accumulator_h accumulator,
+                                             accumulator_iterator_t *iterator) {
+  accumulator_t *p_acc = (accumulator_t *)accumulator;
   if (accumulator_iterator_valid(accumulator, *iterator)) {
     *iterator = (*iterator + 1) % p_acc->total_buffer_size;
     return true;
   } else {
-    //We've reached the end
+    // We've reached the end
     return false;
   }
 }
 
-static inline accumulator_h accumulator_create(accumulator_create_params_t *params)
-{
+static inline accumulator_h accumulator_create(accumulator_create_params_t *params) {
   CUTILS_ASSERTF(params && params->acc, "Invalid params or accumulator static store is bad");
   accumulator_t *acc = params->acc;
   acc->buf = params->buf;
@@ -97,17 +92,15 @@ static inline accumulator_h accumulator_create(accumulator_create_params_t *para
   return acc;
 }
 
-static inline void accumulator_clear(accumulator_h handle)
-{
-  accumulator_t *acc = (accumulator_t *) handle;
+static inline void accumulator_clear(accumulator_h handle) {
+  accumulator_t *acc = (accumulator_t *)handle;
   acc->in = 0;
   acc->out = 0;
 }
 
-static inline uint32_t accumulator_bytes_left(accumulator_h handle)
-{
+static inline uint32_t accumulator_bytes_left(accumulator_h handle) {
   uint32_t retval = 0;
-  accumulator_t *p_acc = (accumulator_t *) handle;
+  accumulator_t *p_acc = (accumulator_t *)handle;
 
   if (p_acc->in >= p_acc->out) {
     retval = p_acc->total_buffer_size - (p_acc->in - p_acc->out);
@@ -117,10 +110,10 @@ static inline uint32_t accumulator_bytes_left(accumulator_h handle)
   return retval - 1;
 }
 
-static inline uint32_t accumulator_bytes_contained_from(accumulator_h handle, accumulator_iterator_t iter)
-{
+static inline uint32_t accumulator_bytes_contained_from(accumulator_h handle,
+                                                        accumulator_iterator_t iter) {
   uint32_t retval = 0;
-  accumulator_t *p_acc = (accumulator_t *) handle;
+  accumulator_t *p_acc = (accumulator_t *)handle;
   if (p_acc->in >= iter) {
     retval = p_acc->in - iter;
   } else {
@@ -131,10 +124,9 @@ static inline uint32_t accumulator_bytes_contained_from(accumulator_h handle, ac
 
 static inline bool accumulator_iterator_advance(accumulator_h accumulator,
                                                 accumulator_iterator_t *iterator,
-                                                uint32_t size)
-{
+                                                uint32_t size) {
   bool retval = false;
-  accumulator_t *p_acc = (accumulator_t *) accumulator;
+  accumulator_t *p_acc = (accumulator_t *)accumulator;
   if (size <= accumulator_bytes_contained_from(accumulator, *iterator) &&
       ((*iterator + size) % p_acc->total_buffer_size) != p_acc->in) {
     *iterator = (*iterator + size) % p_acc->total_buffer_size;
@@ -143,17 +135,19 @@ static inline bool accumulator_iterator_advance(accumulator_h accumulator,
   return retval;
 }
 
-static inline uint32_t accumulator_bytes_contained(accumulator_h handle)
-{
-  return accumulator_bytes_contained_from(handle, ((accumulator_t *) handle)->out);
+static inline uint32_t accumulator_bytes_contained(accumulator_h handle) {
+  return accumulator_bytes_contained_from(handle, ((accumulator_t *)handle)->out);
 }
 
-static inline uint32_t accumulator_to_string(accumulator_h accumulator, char* str, uint32_t string_size)
-{
+static inline uint32_t
+accumulator_to_string(accumulator_h accumulator, char *str, uint32_t string_size) {
   uint32_t retval = 0;
-  accumulator_t *p_acc = (accumulator_t*)accumulator;
-  if( string_size >=  128 ) {
-    INSERT_TO_STRING(str, retval, "acc(in = %"PRIu32", out = %"PRIu32", contained = %"PRIu32", left = %"PRIu32", tot = %"PRIu32")",
+  accumulator_t *p_acc = (accumulator_t *)accumulator;
+  if (string_size >= 128) {
+    INSERT_TO_STRING(str,
+                     retval,
+                     "acc(in = %" PRIu32 ", out = %" PRIu32 ", contained = %" PRIu32
+                     ", left = %" PRIu32 ", tot = %" PRIu32 ")",
                      p_acc->in,
                      p_acc->out,
                      accumulator_bytes_contained(accumulator),
@@ -163,10 +157,9 @@ static inline uint32_t accumulator_to_string(accumulator_h accumulator, char* st
   return retval;
 }
 
-static inline bool accumulator_insert(accumulator_h handle, uint8_t *buf, uint32_t size)
-{
+static inline bool accumulator_insert(accumulator_h handle, uint8_t *buf, uint32_t size) {
   bool retval = false;
-  accumulator_t *p_acc = (accumulator_t *) handle;
+  accumulator_t *p_acc = (accumulator_t *)handle;
   uint32_t bytes_left = accumulator_bytes_left(handle);
 
   if (size < p_acc->total_buffer_size) {
@@ -190,10 +183,9 @@ static inline bool accumulator_insert(accumulator_h handle, uint8_t *buf, uint32
   return retval;
 }
 
-static inline bool accumulator_peek(accumulator_h handle, uint8_t *buf, uint32_t size)
-{
+static inline bool accumulator_peek(accumulator_h handle, uint8_t *buf, uint32_t size) {
   bool retval = false;
-  accumulator_t *p_acc = (accumulator_t *) handle;
+  accumulator_t *p_acc = (accumulator_t *)handle;
   uint32_t bytes_contained = accumulator_bytes_contained(handle);
   if (size <= bytes_contained) {
     if (p_acc->out + size > p_acc->total_buffer_size) {
@@ -208,10 +200,9 @@ static inline bool accumulator_peek(accumulator_h handle, uint8_t *buf, uint32_t
   return retval;
 }
 
-static inline bool accumulator_extract(accumulator_h handle, uint8_t *buf, uint32_t size)
-{
+static inline bool accumulator_extract(accumulator_h handle, uint8_t *buf, uint32_t size) {
   bool retval = false;
-  accumulator_t *p_acc = (accumulator_t *) handle;
+  accumulator_t *p_acc = (accumulator_t *)handle;
   if (accumulator_peek(handle, buf, size)) {
     retval = true;
     p_acc->out = (p_acc->out + size) % p_acc->total_buffer_size;
@@ -219,10 +210,9 @@ static inline bool accumulator_extract(accumulator_h handle, uint8_t *buf, uint3
   return retval;
 }
 
-static inline bool accumulator_advance(accumulator_h handle, uint32_t size)
-{
+static inline bool accumulator_advance(accumulator_h handle, uint32_t size) {
   bool retval = false;
-  accumulator_t *p_acc = (accumulator_t *) handle;
+  accumulator_t *p_acc = (accumulator_t *)handle;
   if (size > p_acc->total_buffer_size - 1) {
     size = p_acc->total_buffer_size - 1;
   }
@@ -230,10 +220,11 @@ static inline bool accumulator_advance(accumulator_h handle, uint32_t size)
   return retval;
 }
 
-static inline uint32_t
-accumulator_peek_at(accumulator_h accumulator, accumulator_iterator_t iter, uint8_t *buf, uint32_t size)
-{
-  accumulator_t *p_acc = (accumulator_t *) accumulator;
+static inline uint32_t accumulator_peek_at(accumulator_h accumulator,
+                                           accumulator_iterator_t iter,
+                                           uint8_t *buf,
+                                           uint32_t size) {
+  accumulator_t *p_acc = (accumulator_t *)accumulator;
   uint32_t bytes_contained = accumulator_bytes_contained_from(accumulator, iter);
   if (size > bytes_contained) {
     size = bytes_contained;

--- a/inc/cutils/asyncio.h
+++ b/inc/cutils/asyncio.h
@@ -41,11 +41,11 @@ typedef void *asyncio_handle_t;
 typedef uint8_t *asyncio_message_t;
 typedef void *asyncio_tx_token_t;
 
-#define STREAM_TX_SEND_STATUS(ACTION)\
-  ACTION(StreamTxSendSuccess,)\
-  ACTION(StreamTxSendHeaderFail,)\
-  ACTION(StreamTxSendMessageFail,)\
-  ACTION(StreamTxInterfaceInError,)
+#define STREAM_TX_SEND_STATUS(ACTION)                                                              \
+  ACTION(StreamTxSendSuccess, )                                                                    \
+  ACTION(StreamTxSendHeaderFail, )                                                                 \
+  ACTION(StreamTxSendMessageFail, )                                                                \
+  ACTION(StreamTxInterfaceInError, )
 
 DECLARE_ENUM(asyncio_tx_send_status_e, STREAM_TX_SEND_STATUS)
 
@@ -60,7 +60,9 @@ DECLARE_ENUM(asyncio_tx_send_status_e, STREAM_TX_SEND_STATUS)
  * @param pPrivate - Private data provided at time of
  *                 registration.
  */
-typedef void (*asyncio_rx_callback_f)(asyncio_handle_t h_asyncio, asyncio_message_t pMessage, size_t size);
+typedef void (*asyncio_rx_callback_f)(asyncio_handle_t h_asyncio,
+                                      asyncio_message_t pMessage,
+                                      size_t size);
 
 /**
  * asyncio_tx_notification_f - Called when a set number of bytes has
@@ -105,25 +107,23 @@ typedef size_t (*asyncio_interface_client_read_f)(asyncio_handle_t handle,
  * @return size_t - Number of bytes written
  */
 
-typedef size_t(*asyncio_interface_client_write_f)(asyncio_handle_t handle,
-                                                  size_t tx_data_size,
-                                                  uint8_t *p_tx_data_buf,
-                                                  uint32_t timeout);
+typedef size_t (*asyncio_interface_client_write_f)(asyncio_handle_t handle,
+                                                   size_t tx_data_size,
+                                                   uint8_t *p_tx_data_buf,
+                                                   uint32_t timeout);
 
-#define ASYNCIO_MAX_THREAD_NAME              ( 40 )
-#define ASYNCIO_SERVICE_UNUSED               (0)
+#define ASYNCIO_MAX_THREAD_NAME (40)
+#define ASYNCIO_SERVICE_UNUSED (0)
 
-
-#define ASYNCIO_INIT_STATE_E(XX)\
-  XX(AsyncioUninitialized,)\
-  XX(AsyncioUninitializing,)\
-  XX(AsyncioInitializing, )\
+#define ASYNCIO_INIT_STATE_E(XX)                                                                   \
+  XX(AsyncioUninitialized, )                                                                       \
+  XX(AsyncioUninitializing, )                                                                      \
+  XX(AsyncioInitializing, )                                                                        \
   XX(AsyncioInitialized, )
 
 DECLARE_ENUM(asyncio_init_state_e, ASYNCIO_INIT_STATE_E)
 
-typedef struct _asyncio_rx_thread_context
-{
+typedef struct _asyncio_rx_thread_context {
   dispatch_queue_t *worker;
   pool_create_params_t rx_pool_params;
   pool_t *buffer_pool;
@@ -133,16 +133,14 @@ typedef struct _asyncio_rx_thread_context
   atomic_int init_state;
 } asyncio_rx_thread_context_t;
 
-typedef struct _asyncio_tx_request
-{
+typedef struct _asyncio_tx_request {
   uint32_t size;
   uint32_t buffer_offset;
   asyncio_tx_notification_f fn;
   void *p_private;
 } asyncio_tx_request_t;
 
-typedef struct _asyncio_tx_thread_context_t
-{
+typedef struct _asyncio_tx_thread_context_t {
   dispatch_queue_t *worker;
   pool_create_params_t pool_create_params;
   char thread_name[ASYNCIO_MAX_THREAD_NAME];
@@ -153,8 +151,7 @@ typedef struct _asyncio_tx_thread_context_t
   atomic_int init_state;
 } asyncio_tx_thread_context_t;
 
-typedef struct _asyncio_interface_instance_t
-{
+typedef struct _asyncio_interface_instance_t {
   asyncio_rx_thread_context_t rx_task;
   asyncio_tx_thread_context_t tx_task;
   asyncio_interface_client_read_f f_stream_interface_read;
@@ -167,8 +164,7 @@ typedef struct _asyncio_interface_instance_t
   atomic_int init_state;
 } asyncio_interface_instance_t;
 
-typedef struct _asyncio_create_params_t
-{
+typedef struct _asyncio_create_params_t {
   const char *stream_name;
 
   // Client callbacks and parameters
@@ -190,41 +186,50 @@ typedef struct _asyncio_create_params_t
   uint32_t tx_buffer_offset;
 } asyncio_create_params_t;
 
-#define ASYNCIO_STORE(name)       _asyncio_store_##name
-#define ASYNCIO_STORE_T(name)     _asyncio_store_##name##_t
+#define ASYNCIO_STORE(name) _asyncio_store_##name
+#define ASYNCIO_STORE_T(name) _asyncio_store_##name##_t
 
-#define ASYNCIO_STORE_DECL(name, rx_max_buffers, tx_max_buffers, rx_max_buf_size, tx_max_buf_size, buffer_align)\
-typedef struct {\
-  asyncio_tx_request_t request;\
-  uint8_t payload[ (tx_max_buf_size)?tx_max_buf_size:buffer_align ] __attribute__((aligned(buffer_align)));\
-}__asyncio_##name##_tx_message_t;\
-POOL_STORE_DECL( name##_tx, ((tx_max_buffers)?tx_max_buffers:1), sizeof(__asyncio_##name##_tx_message_t), buffer_align);\
-POOL_STORE_DECL( name##_rx, ((rx_max_buffers)?rx_max_buffers:1), (rx_max_buf_size)?rx_max_buf_size:buffer_align, buffer_align );\
-typedef struct {\
-  asyncio_interface_instance_t instance;\
-}ASYNCIO_STORE_T( name );\
-static uint32_t __tx_max_buf_size_##name = (tx_max_buf_size)?tx_max_buf_size:buffer_align;
+#define ASYNCIO_STORE_DECL(                                                                        \
+    name, rx_max_buffers, tx_max_buffers, rx_max_buf_size, tx_max_buf_size, buffer_align)          \
+  typedef struct {                                                                                 \
+    asyncio_tx_request_t request;                                                                  \
+    uint8_t payload[(tx_max_buf_size) ? tx_max_buf_size : buffer_align]                            \
+        __attribute__((aligned(buffer_align)));                                                    \
+  } __asyncio_##name##_tx_message_t;                                                               \
+  POOL_STORE_DECL(name##_tx,                                                                       \
+                  ((tx_max_buffers) ? tx_max_buffers : 1),                                         \
+                  sizeof(__asyncio_##name##_tx_message_t),                                         \
+                  buffer_align);                                                                   \
+  POOL_STORE_DECL(name##_rx,                                                                       \
+                  ((rx_max_buffers) ? rx_max_buffers : 1),                                         \
+                  (rx_max_buf_size) ? rx_max_buf_size : buffer_align,                              \
+                  buffer_align);                                                                   \
+  typedef struct {                                                                                 \
+    asyncio_interface_instance_t instance;                                                         \
+  } ASYNCIO_STORE_T(name);                                                                         \
+  static uint32_t __tx_max_buf_size_##name = (tx_max_buf_size) ? tx_max_buf_size : buffer_align;
 
-#define ASYNCIO_STORE_DEF(name)\
-POOL_STORE_DEF(name##_tx);\
-POOL_STORE_DEF(name##_rx);\
-ASYNCIO_STORE_T( name ) ASYNCIO_STORE( name ) = { 0 }
+#define ASYNCIO_STORE_DEF(name)                                                                    \
+  POOL_STORE_DEF(name##_tx);                                                                       \
+  POOL_STORE_DEF(name##_rx);                                                                       \
+  ASYNCIO_STORE_T(name) ASYNCIO_STORE(name) = {0}
 
-#define ASYNCIO_CREATE_PARAMS_INIT(params, name, st_name, read_fn, write_fn, rx_cb, rx_dq, tx_dq, p_priv) do{\
-  (params).stream_name = st_name;\
-  (params).p_instance = &ASYNCIO_STORE( name ).instance;\
-  (params).read_f = read_fn;\
-  (params).write_f = write_fn;\
-  (params).rx_callback = rx_cb;\
-  (params).client_data = p_priv;\
-  (params).rx_worker = rx_dq,\
-  POOL_CREATE_INIT((params).rx_pool_create_params, name##_rx);\
-  (params).tx_worker = tx_dq;\
-  POOL_CREATE_INIT((params).tx_pool_create_params, name##_tx);\
-  (params).tx_buffer_offset = offsetof(__asyncio_##name##_tx_message_t, payload);\
-  (params).tx_max_chunk_size = __tx_max_buf_size_##name;\
-  (params).tx_write_timeout = 4000;\
-}while( 0 )
+#define ASYNCIO_CREATE_PARAMS_INIT(                                                                \
+    params, name, st_name, read_fn, write_fn, rx_cb, rx_dq, tx_dq, p_priv)                         \
+  do {                                                                                             \
+    (params).stream_name = st_name;                                                                \
+    (params).p_instance = &ASYNCIO_STORE(name).instance;                                           \
+    (params).read_f = read_fn;                                                                     \
+    (params).write_f = write_fn;                                                                   \
+    (params).rx_callback = rx_cb;                                                                  \
+    (params).client_data = p_priv;                                                                 \
+    (params).rx_worker = rx_dq, POOL_CREATE_INIT((params).rx_pool_create_params, name##_rx);       \
+    (params).tx_worker = tx_dq;                                                                    \
+    POOL_CREATE_INIT((params).tx_pool_create_params, name##_tx);                                   \
+    (params).tx_buffer_offset = offsetof(__asyncio_##name##_tx_message_t, payload);                \
+    (params).tx_max_chunk_size = __tx_max_buf_size_##name;                                         \
+    (params).tx_write_timeout = 4000;                                                              \
+  } while (0)
 
 asyncio_handle_t asyncio_create_instance(asyncio_create_params_t *p_params);
 
@@ -242,11 +247,12 @@ uint32_t asyncio_tx_token_get_max_data_size(asyncio_handle_t h_asyncio);
 
 bool asyncio_send_buffer(asyncio_handle_t h_asyncio,
                          asyncio_tx_token_t token,
-                         uint32_t size, asyncio_tx_notification_f fn, void *p_private);
+                         uint32_t size,
+                         asyncio_tx_notification_f fn,
+                         void *p_private);
 
 void asyncio_release_rx_buffer(asyncio_handle_t h_asyncio, asyncio_message_t message);
 
 void asyncio_release_tx_token(asyncio_handle_t h_asyncio, asyncio_tx_token_t token);
 
 void *asyncio_get_private_data(asyncio_handle_t h_asyncio);
-

--- a/inc/cutils/bst.h
+++ b/inc/cutils/bst.h
@@ -30,15 +30,12 @@ typedef int (*bst_less_f)(KListElem *elem1, KListElem *elem2);
 
 typedef void (*bst_traverse_f)(KListElem *elem, va_list args);
 
-typedef struct _bst_t
-{
+typedef struct _bst_t {
   KListHead *root;
   bst_less_f f_less;
 } bst_t;
 
-
-static inline void bst_init(bst_t *bst, bst_less_f f_less)
-{
+static inline void bst_init(bst_t *bst, bst_less_f f_less) {
   if (bst && f_less) {
     bst->f_less = f_less;
     bst->root = 0;

--- a/inc/cutils/c11/c11threads.h
+++ b/inc/cutils/c11/c11threads.h
@@ -28,14 +28,14 @@
 #define C11THREADS_H_
 
 #include <cutils/logger.h>
-#include <time.h>
 #include <errno.h>
 #include <pthread.h>
-#include <sched.h>	/* for sched_yield */
+#include <sched.h> /* for sched_yield */
 #include <sys/time.h>
+#include <time.h>
 
-#define ONCE_FLAG_INIT	PTHREAD_ONCE_INIT
-#define SCHEDULING_POLICY       (SCHED_OTHER)
+#define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
+#define SCHEDULING_POLICY (SCHED_OTHER)
 
 #ifdef __APPLE__
 /* Darwin doesn't implement timed mutexes currently */
@@ -44,7 +44,7 @@
 
 #ifdef C11THREADS_NO_TIMED_MUTEX
 #define PTHREAD_MUTEX_TIMED_NP PTHREAD_MUTEX_NORMAL
-#define C11THREADS_TIMEDLOCK_POLL_INTERVAL 5000000	/* 5 ms */
+#define C11THREADS_TIMEDLOCK_POLL_INTERVAL 5000000 /* 5 ms */
 #endif
 
 /* types */
@@ -54,33 +54,25 @@ typedef pthread_cond_t cnd_t;
 typedef pthread_key_t tss_t;
 typedef pthread_once_t once_flag;
 
-typedef int (*thrd_start_t)(void*);
-typedef void (*tss_dtor_t)(void*);
+typedef int (*thrd_start_t)(void *);
+typedef void (*tss_dtor_t)(void *);
 
 enum {
-  mtx_plain		= 0,
-  mtx_recursive	= 1,
-  mtx_timed		= 2,
+  mtx_plain = 0,
+  mtx_recursive = 1,
+  mtx_timed = 2,
 };
 
-enum {
-  thrd_success,
-  thrd_timedout,
-  thrd_busy,
-  thrd_error,
-  thrd_nomem
-};
-
+enum { thrd_success, thrd_timedout, thrd_busy, thrd_error, thrd_nomem };
 
 /* ---- thread management ---- */
 
-static inline int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
-{
-  pthread_attr_t attr = { 0};
+static inline int thrd_create(thrd_t *thr, thrd_start_t func, void *arg) {
+  pthread_attr_t attr = {0};
   pthread_attr_init(&attr);
 
-  int res = pthread_create(thr, &attr, (void*(*)(void*))func, arg);
-  if(res == 0) {
+  int res = pthread_create(thr, &attr, (void *(*)(void *))func, arg);
+  if (res == 0) {
     return thrd_success;
   }
   pthread_attr_destroy(&attr);
@@ -90,12 +82,11 @@ static inline int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
 static inline int thrd_create_ex(thrd_t *thr,
                                  thrd_start_t func,
                                  void *arg,
-                                 char* label,
+                                 char *label,
                                  int priority,
                                  void *stack,
-                                 size_t stack_size)
-{
-  pthread_attr_t attr =  { 0 };
+                                 size_t stack_size) {
+  pthread_attr_t attr = {0};
   size_t min_stack_size = 0;
   pthread_attr_init(&attr);
 
@@ -107,85 +98,75 @@ static inline int thrd_create_ex(thrd_t *thr,
   CHECK_RUN(!rval, pthread_attr_destroy(&attr); return rval, "Failed to set scheduling policy");
   struct sched_param param = {.sched_priority = priority};
   rval = pthread_attr_setschedparam(&attr, &param);
-  CHECK_RUN(!rval, pthread_attr_destroy(&attr); return rval, "Failed to set priority to %d", param.sched_priority);
-  if(stack && stack_size >= min_stack_size) {
+  CHECK_RUN(!rval, pthread_attr_destroy(&attr);
+            return rval, "Failed to set priority to %d", param.sched_priority);
+  if (stack && stack_size >= min_stack_size) {
     rval = pthread_attr_setstackaddr(&attr, stack);
-    CHECK_RUN(!rval, pthread_attr_destroy(&attr); return rval, "Failed to set stack address", stack);
+    CHECK_RUN(!rval, pthread_attr_destroy(&attr);
+              return rval, "Failed to set stack address", stack);
     rval = pthread_attr_setstacksize(&attr, stack_size);
     CHECK_RUN(!rval, pthread_attr_destroy(&attr); return rval, "Failed to set stack size");
   }
-  CHECK_RUN(!rval, pthread_attr_destroy(&attr); return rval, "Failed to set scheduling priority between (%d, %d)",
-                sched_get_priority_min(SCHEDULING_POLICY), sched_get_priority_max(SCHEDULING_POLICY) );
-  int res = pthread_create(thr, &attr, (void*(*)(void*))func, arg);
+  CHECK_RUN(!rval, pthread_attr_destroy(&attr);
+            return rval,
+                   "Failed to set scheduling priority between (%d, %d)",
+                   sched_get_priority_min(SCHEDULING_POLICY),
+                   sched_get_priority_max(SCHEDULING_POLICY));
+  int res = pthread_create(thr, &attr, (void *(*)(void *))func, arg);
   pthread_attr_destroy(&attr);
-  if(res == 0) {
+  if (res == 0) {
     pthread_setname_np(*thr, label);
     return thrd_success;
-  }else {
+  } else {
     return thrd_error;
   }
 }
 
-static inline void thrd_exit(int res)
-{
-  pthread_exit((void*)&res);
-}
+static inline void thrd_exit(int res) { pthread_exit((void *)&res); }
 
-static inline int thrd_join(thrd_t thr, int *res)
-{
+static inline int thrd_join(thrd_t thr, int *res) {
   void *retval;
 
-  if(pthread_join(thr, &retval) != 0) {
+  if (pthread_join(thr, &retval) != 0) {
     return thrd_error;
   }
-  if(res) {
-    *res = *((int*)&retval);
+  if (res) {
+    *res = *((int *)&retval);
   }
   return thrd_success;
 }
 
-static inline int thrd_detach(thrd_t thr)
-{
+static inline int thrd_detach(thrd_t thr) {
   return pthread_detach(thr) == 0 ? thrd_success : thrd_error;
 }
 
-static inline thrd_t thrd_current(void)
-{
-  return pthread_self();
-}
+static inline thrd_t thrd_current(void) { return pthread_self(); }
 
-static inline int thrd_equal(thrd_t a, thrd_t b)
-{
-  return pthread_equal(a, b);
-}
+static inline int thrd_equal(thrd_t a, thrd_t b) { return pthread_equal(a, b); }
 
-static inline int thrd_sleep(const struct timespec *ts_in, struct timespec *rem_out)
-{
-  if(nanosleep(ts_in, rem_out) < 0) {
-    if(errno == EINTR) return -1;
+static inline int thrd_sleep(const struct timespec *ts_in, struct timespec *rem_out) {
+  if (nanosleep(ts_in, rem_out) < 0) {
+    if (errno == EINTR)
+      return -1;
     return -2;
   }
   return 0;
 }
 
-static inline void thrd_yield(void)
-{
-  sched_yield();
-}
+static inline void thrd_yield(void) { sched_yield(); }
 
 /* ---- mutexes ---- */
 
-static inline int mtx_init(mtx_t *mtx, int type)
-{
+static inline int mtx_init(mtx_t *mtx, int type) {
   int res;
   pthread_mutexattr_t attr;
 
   pthread_mutexattr_init(&attr);
 
-  if(type & mtx_timed) {
+  if (type & mtx_timed) {
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_TIMED_NP);
   }
-  if(type & mtx_recursive) {
+  if (type & mtx_recursive) {
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
   }
 
@@ -194,95 +175,80 @@ static inline int mtx_init(mtx_t *mtx, int type)
   return res;
 }
 
-static inline void mtx_destroy(mtx_t *mtx)
-{
-  pthread_mutex_destroy(mtx);
-}
+static inline void mtx_destroy(mtx_t *mtx) { pthread_mutex_destroy(mtx); }
 
-static inline int mtx_lock(mtx_t *mtx)
-{
+static inline int mtx_lock(mtx_t *mtx) {
   int res = pthread_mutex_lock(mtx);
-  if(res == EDEADLK) {
+  if (res == EDEADLK) {
     return thrd_busy;
   }
   return res == 0 ? thrd_success : thrd_error;
 }
 
-static inline int mtx_trylock(mtx_t *mtx)
-{
+static inline int mtx_trylock(mtx_t *mtx) {
   int res = pthread_mutex_trylock(mtx);
-  if(res == EBUSY) {
+  if (res == EBUSY) {
     return thrd_busy;
   }
   return res == 0 ? thrd_success : thrd_error;
 }
 
-static inline int mtx_timedlock(mtx_t *mtx, const struct timespec *ts)
-{
+static inline int mtx_timedlock(mtx_t *mtx, const struct timespec *ts) {
   int res;
 #ifdef C11THREADS_NO_TIMED_MUTEX
   /* fake a timedlock by polling trylock in a loop and waiting for a bit */
-	struct timeval now;
-	struct timespec sleeptime;
+  struct timeval now;
+  struct timespec sleeptime;
 
-	sleeptime.tv_sec = 0;
-	sleeptime.tv_nsec = C11THREADS_TIMEDLOCK_POLL_INTERVAL;
+  sleeptime.tv_sec = 0;
+  sleeptime.tv_nsec = C11THREADS_TIMEDLOCK_POLL_INTERVAL;
 
-	while((res = pthread_mutex_trylock(mtx)) == EBUSY) {
-		gettimeofday(&now, NULL);
+  while ((res = pthread_mutex_trylock(mtx)) == EBUSY) {
+    gettimeofday(&now, NULL);
 
-		if(now.tv_sec > ts->tv_sec || (now.tv_sec == ts->tv_sec &&
-					(now.tv_usec * 1000) >= ts->tv_nsec)) {
-			return thrd_timedout;
-		}
+    if (now.tv_sec > ts->tv_sec ||
+        (now.tv_sec == ts->tv_sec && (now.tv_usec * 1000) >= ts->tv_nsec)) {
+      return thrd_timedout;
+    }
 
-		nanosleep(&sleeptime, NULL);
-	}
+    nanosleep(&sleeptime, NULL);
+  }
 #else
-  if((res = pthread_mutex_timedlock(mtx, ts)) == ETIMEDOUT) {
+  if ((res = pthread_mutex_timedlock(mtx, ts)) == ETIMEDOUT) {
     return thrd_timedout;
   }
 #endif
   return res == 0 ? thrd_success : thrd_error;
 }
 
-static inline int mtx_unlock(mtx_t *mtx)
-{
+static inline int mtx_unlock(mtx_t *mtx) {
   return pthread_mutex_unlock(mtx) == 0 ? thrd_success : thrd_error;
 }
 
 /* ---- condition variables ---- */
 
-static inline int cnd_init(cnd_t *cond)
-{
+static inline int cnd_init(cnd_t *cond) {
   return pthread_cond_init(cond, 0) == 0 ? thrd_success : thrd_error;
 }
 
-static inline void cnd_destroy(cnd_t *cond)
-{
-  pthread_cond_destroy(cond);
-}
+static inline void cnd_destroy(cnd_t *cond) { pthread_cond_destroy(cond); }
 
-static inline int cnd_signal(cnd_t *cond)
-{
+static inline int cnd_signal(cnd_t *cond) {
   return pthread_cond_signal(cond) == 0 ? thrd_success : thrd_error;
 }
 
-static inline int cnd_broadcast(cnd_t *cond)
-{
+static inline int cnd_broadcast(cnd_t *cond) {
   return pthread_cond_broadcast(cond) == 0 ? thrd_success : thrd_error;
 }
 
-static inline int cnd_wait(cnd_t *cond, mtx_t *mtx)
-{
+static inline int cnd_wait(cnd_t *cond, mtx_t *mtx) {
   return pthread_cond_wait(cond, mtx) == 0 ? thrd_success : thrd_error;
 }
 
-static inline int cnd_timedwait(cnd_t *cond, mtx_t *mtx, const struct timespec *ts)
-{
+static inline int cnd_timedwait(cnd_t *cond, mtx_t *mtx, const struct timespec *ts) {
   int res;
 
-  if((res = pthread_cond_timedwait(cond, mtx, ts)) != 0) {
+  if ((res = pthread_cond_timedwait(cond, mtx, ts)) != 0) {
     return res == ETIMEDOUT ? thrd_timedout : thrd_error;
   }
   return thrd_success;
@@ -290,34 +256,23 @@ static inline int cnd_timedwait(cnd_t *cond, mtx_t *mtx, const struct timespec *
 
 /* ---- thread-specific data ---- */
 
-static inline int tss_create(tss_t *key, tss_dtor_t dtor)
-{
+static inline int tss_create(tss_t *key, tss_dtor_t dtor) {
   return pthread_key_create(key, dtor) == 0 ? thrd_success : thrd_error;
 }
 
-static inline void tss_delete(tss_t key)
-{
-  pthread_key_delete(key);
-}
+static inline void tss_delete(tss_t key) { pthread_key_delete(key); }
 
-static inline int tss_set(tss_t key, void *val)
-{
+static inline int tss_set(tss_t key, void *val) {
   return pthread_setspecific(key, val) == 0 ? thrd_success : thrd_error;
 }
 
-static inline void *tss_get(tss_t key)
-{
-  return pthread_getspecific(key);
-}
+static inline void *tss_get(tss_t key) { return pthread_getspecific(key); }
 
 /* ---- misc ---- */
 
-static inline void call_once(once_flag *flag, void (*func)(void))
-{
-  pthread_once(flag, func);
-}
+static inline void call_once(once_flag *flag, void (*func)(void)) { pthread_once(flag, func); }
 
-#if 0 //__STDC_VERSION__ < 201112L || defined(C11THREADS_NO_TIMED_MUTEX)
+#if 0  //__STDC_VERSION__ < 201112L || defined(C11THREADS_NO_TIMED_MUTEX)
 /* TODO take base into account */
 static inline int timespec_get(struct timespec *ts, int base)
 {
@@ -329,7 +284,7 @@ static inline int timespec_get(struct timespec *ts, int base)
   ts->tv_nsec = tv.tv_usec * 1000;
   return base;
 }
-#endif	/* not C11 */
+#endif /* not C11 */
 
-#endif	/* C11THREADS_H_ */
-#endif //CUTILS_C11THREADS_H
+#endif /* C11THREADS_H_ */
+#endif // CUTILS_C11THREADS_H

--- a/inc/cutils/c11/event_flag.h
+++ b/inc/cutils/c11/event_flag.h
@@ -23,23 +23,21 @@
  */
 #pragma once
 
-#include <cutils/os_types.h>
 #include <cutils/c11/c11threads.h>
+#include <cutils/os_types.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef enum _event_flag_wait_type_e
-{
+typedef enum _event_flag_wait_type_e {
   WAIT_OR,
   WAIT_OR_CLEAR,
   WAIT_AND,
   WAIT_AND_CLEAR
 } event_flag_wait_type_e;
 
-typedef struct _event_flag_t
-{
+typedef struct _event_flag_t {
   cnd_t cv;
   mtx_t mtx;
   uint32_t val;
@@ -49,8 +47,11 @@ bool event_flag_new(event_flag_t *p_flags);
 
 bool event_flag_free(event_flag_t *p_flags);
 
-bool event_flag_wait(event_flag_t *p_flags, uint32_t required_flags, event_flag_wait_type_e wait_type,
-                                   uint32_t *p_actual_flags, uint32_t wait_ms);
+bool event_flag_wait(event_flag_t *p_flags,
+                     uint32_t required_flags,
+                     event_flag_wait_type_e wait_type,
+                     uint32_t *p_actual_flags,
+                     uint32_t wait_ms);
 
 bool event_flag_send(event_flag_t *p_flags, uint32_t flag_bits);
 

--- a/inc/cutils/c11/mutex.h
+++ b/inc/cutils/c11/mutex.h
@@ -23,55 +23,48 @@
  */
 #pragma once
 
-#include <cutils/os_types.h>
 #include <cutils/c11/c11threads.h>
+#include <cutils/os_types.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-typedef struct _mutex_t
-{
+typedef struct _mutex_t {
   mtx_t mtx;
 } mutex_t;
 
-static inline bool mutex_new(mutex_t *mutex)
-{
+static inline bool mutex_new(mutex_t *mutex) {
   bool retval = false;
-  if (mutex &&
-      !mtx_init(&mutex->mtx, mtx_timed)) {
+  if (mutex && !mtx_init(&mutex->mtx, mtx_timed)) {
     retval = true;
   }
   return retval;
 }
 
-static inline void mutex_free(mutex_t *mutex)
-{
+static inline void mutex_free(mutex_t *mutex) {
   if (mutex) {
     mtx_destroy(&mutex->mtx);
   }
 }
 
-static inline bool mutex_lock(mutex_t *mutex, uint32_t wait_ms)
-{
+static inline bool mutex_lock(mutex_t *mutex, uint32_t wait_ms) {
   bool retval = false;
   if (mutex) {
-    if(!wait_ms) {
+    if (!wait_ms) {
       retval = !mtx_trylock(&mutex->mtx);
     } else {
       struct timespec tm = {0};
       clock_gettime(CLOCK_REALTIME, &tm);
-      tm.tv_sec += wait_ms/1000;
-      tm.tv_nsec += 1000000 * ( wait_ms % 1000);
+      tm.tv_sec += wait_ms / 1000;
+      tm.tv_nsec += 1000000 * (wait_ms % 1000);
       retval = (!mtx_timedlock(&mutex->mtx, &tm));
     }
   }
   return retval;
 }
 
-static inline bool mutex_unlock(mutex_t *mutex)
-{
+static inline bool mutex_unlock(mutex_t *mutex) {
   bool retval = false;
   if (mutex) {
     retval = (!mtx_unlock(&mutex->mtx));

--- a/inc/cutils/c11/task.h
+++ b/inc/cutils/c11/task.h
@@ -23,37 +23,38 @@
  */
 #pragma once
 
-#include <cutils/os_types.h>
 #include <cutils/c11/c11threads.h>
+#include <cutils/os_types.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define CUTILS_TASK_PRIORITY_LOWEST     (sched_get_priority_min(SCHEDULING_POLICY))
-#define CUTILS_TASK_PRIORITY_HIGHEST    (sched_get_priority_max(SCHEDULING_POLICY))
-#define CUTILS_TASK_PRIORITY_MEDIUM     (( CUTILS_TASK_PRIORITY_LOWEST + CUTILS_TASK_PRIORITY_HIGHEST ) / 2)
-#define CUTILS_TASK_PRIORITY_MID_HIGH   (CUTILS_TASK_PRIORITY_MEDIUM - ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST)/4))
-#define CUTILS_TASK_PRIORITY_MID_LO     (CUTILS_TASK_PRIORITY_MEDIUM + ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST)/4))
+#define CUTILS_TASK_PRIORITY_LOWEST (sched_get_priority_min(SCHEDULING_POLICY))
+#define CUTILS_TASK_PRIORITY_HIGHEST (sched_get_priority_max(SCHEDULING_POLICY))
+#define CUTILS_TASK_PRIORITY_MEDIUM                                                                \
+  ((CUTILS_TASK_PRIORITY_LOWEST + CUTILS_TASK_PRIORITY_HIGHEST) / 2)
+#define CUTILS_TASK_PRIORITY_MID_HIGH                                                              \
+  (CUTILS_TASK_PRIORITY_MEDIUM - ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST) / 4))
+#define CUTILS_TASK_PRIORITY_MID_LO                                                                \
+  (CUTILS_TASK_PRIORITY_MEDIUM + ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST) / 4))
 
-#define CUTILS_TASK_STACK_MIN_SIZE               (PTHREAD_STACK_MIN)
+#define CUTILS_TASK_STACK_MIN_SIZE (PTHREAD_STACK_MIN)
 #define DEFAULT_TASK_PRIORITY CUTILS_TASK_PRIORITY_MEDIUM
 
 /**
  * @brief Prototype for task_t function callbcak
  */
-typedef void (*task_func_t )(void *);
+typedef void (*task_func_t)(void *);
 
-typedef struct _task_t
-{
+typedef struct _task_t {
   thrd_t task;
   char label[30];
   task_func_t func;
   void *ctx;
 } task_t;
 
-typedef struct _task_create_params_t
-{
+typedef struct _task_create_params_t {
   task_t *task;
   char *label;
   uint32_t priority;
@@ -67,23 +68,23 @@ typedef struct _task_create_params_t
 
 #define TASK_STATIC_STORE(name) _task_store_##name
 
-#define TASK_STATIC_STORE_DECL(name, stack_size)\
-typedef struct {\
-  uint8_t stack[ (stack_size) ];\
-  task_t tsk;\
-}TASK_STATIC_STORE_T( name )
+#define TASK_STATIC_STORE_DECL(name, stack_size)                                                   \
+  typedef struct {                                                                                 \
+    uint8_t stack[(stack_size)];                                                                   \
+    task_t tsk;                                                                                    \
+  } TASK_STATIC_STORE_T(name)
 
-#define TASK_STATIC_STORE_DEF(name)\
-TASK_STATIC_STORE_T( name ) TASK_STATIC_STORE(name) __attribute__((section(".bss.noinit"),used))
+#define TASK_STATIC_STORE_DEF(name)                                                                \
+  TASK_STATIC_STORE_T(name) TASK_STATIC_STORE(name) __attribute__((section(".bss.noinit"), used))
 
-#define TASK_STATIC_INIT_CREATE_PARAMS(params, name, lbl, pri, fn, context)\
-  memset(&(params), 0, sizeof((params)));\
-  (params).task = &TASK_STATIC_STORE(name).tsk;\
-  (params).label = (char*)(lbl);\
-  (params).priority = pri;\
-  (params).func = fn;\
-  (params).ctx = context;\
-  (params).stack = TASK_STATIC_STORE(name).stack;\
+#define TASK_STATIC_INIT_CREATE_PARAMS(params, name, lbl, pri, fn, context)                        \
+  memset(&(params), 0, sizeof((params)));                                                          \
+  (params).task = &TASK_STATIC_STORE(name).tsk;                                                    \
+  (params).label = (char *)(lbl);                                                                  \
+  (params).priority = pri;                                                                         \
+  (params).func = fn;                                                                              \
+  (params).ctx = context;                                                                          \
+  (params).stack = TASK_STATIC_STORE(name).stack;                                                  \
   (params).stack_size = sizeof(TASK_STATIC_STORE(name).stack)
 
 task_t *task_new_static(task_create_params_t *create_params);

--- a/inc/cutils/c11/ts_queue.h
+++ b/inc/cutils/c11/ts_queue.h
@@ -9,10 +9,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,12 +22,11 @@
  * THE SOFTWARE.
  */
 
-
 #ifndef CUTILS_C11_TS_QUEUE_H
 #define CUTILS_C11_TS_QUEUE_H
 
-#include <cutils/mutex.h>
 #include <cutils/c11/c11threads.h>
+#include <cutils/mutex.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,50 +36,49 @@ typedef struct {
   cnd_t cnd;
   cnd_t full_cnd;
   mutex_t mtx;
-  void** pp_ptr_array;
+  void **pp_ptr_array;
   size_t size;
   size_t count;
   atomic_ulong head;
   atomic_ulong tail;
-}ts_queue_t;
+} ts_queue_t;
 
-#define TS_QUEUE_STORE(name)      _ts_queue_store_##name
-#define TS_QUEUE_STORE_T(name)    _ts_queue_store_##name##_t
-#define TS_QUEUE_STORE_DECL(name, size) \
-static size_t _ts_queue_store_num_elements_##name = size;\
-typedef struct {\
-  void* ptr_array[size];\
-  ts_queue_t queue;\
-}TS_QUEUE_STORE_T(name)
+#define TS_QUEUE_STORE(name) _ts_queue_store_##name
+#define TS_QUEUE_STORE_T(name) _ts_queue_store_##name##_t
+#define TS_QUEUE_STORE_DECL(name, size)                                                            \
+  static size_t _ts_queue_store_num_elements_##name = size;                                        \
+  typedef struct {                                                                                 \
+    void *ptr_array[size];                                                                         \
+    ts_queue_t queue;                                                                              \
+  } TS_QUEUE_STORE_T(name)
 
-#define TS_QUEUE_STORE_DEF(name) \
-static TS_QUEUE_STORE_T(name) TS_QUEUE_STORE(name)
+#define TS_QUEUE_STORE_DEF(name) static TS_QUEUE_STORE_T(name) TS_QUEUE_STORE(name)
 
 typedef struct {
-  ts_queue_t* p_queue;
+  ts_queue_t *p_queue;
   void **ptr_array;
   size_t size;
-}ts_queue_create_params_t;
+} ts_queue_create_params_t;
 
-#define TS_QUEUE_STORE_CREATE_PARAMS_INIT(params, name) \
-memset(&(params), 0, sizeof((params)));\
-(params).p_queue = &TS_QUEUE_STORE(name).queue;\
-(params).ptr_array = TS_QUEUE_STORE(name).ptr_array;\
-(params).size = _ts_queue_store_num_elements_##name
+#define TS_QUEUE_STORE_CREATE_PARAMS_INIT(params, name)                                            \
+  memset(&(params), 0, sizeof((params)));                                                          \
+  (params).p_queue = &TS_QUEUE_STORE(name).queue;                                                  \
+  (params).ptr_array = TS_QUEUE_STORE(name).ptr_array;                                             \
+  (params).size = _ts_queue_store_num_elements_##name
 
-static inline ts_queue_t *ts_queue_init(ts_queue_create_params_t *params)
-{
+static inline ts_queue_t *ts_queue_init(ts_queue_create_params_t *params) {
   ts_queue_t *retval = 0;
-  if(params && params->p_queue && params->ptr_array) {
+  if (params && params->p_queue && params->ptr_array) {
     params->p_queue->pp_ptr_array = params->ptr_array;
     params->p_queue->size = params->size;
-    CHECK_RUN(params->p_queue->size > 0 && (params->p_queue->size & (params->p_queue->size -1)) == 0,
-        return retval, "Queue Size must be a power of 2");
+    CHECK_RUN(params->p_queue->size > 0 &&
+                  (params->p_queue->size & (params->p_queue->size - 1)) == 0,
+              return retval,
+              "Queue Size must be a power of 2");
     CHECK_RUN(mutex_new(&params->p_queue->mtx), return retval, "Failed to create Mutex");
     CHECK_RUN(!cnd_init(&params->p_queue->cnd) && !cnd_init(&params->p_queue->full_cnd),
               mutex_free(&params->p_queue->mtx);
-              return retval,
-              "Failed to create Condition variable");
+              return retval, "Failed to create Condition variable");
     params->p_queue->count = 0;
     params->p_queue->head = params->p_queue->tail = 0;
     retval = params->p_queue;
@@ -88,35 +86,33 @@ static inline ts_queue_t *ts_queue_init(ts_queue_create_params_t *params)
   return retval;
 }
 
-static inline void ts_queue_destroy(ts_queue_t *p_queue)
-{
-  if(p_queue) {
+static inline void ts_queue_destroy(ts_queue_t *p_queue) {
+  if (p_queue) {
     cnd_destroy(&p_queue->cnd);
     mutex_free(&p_queue->mtx);
   }
 }
 
-static inline bool ts_queue_enqueue(ts_queue_t* p_queue, void* p_item, uint32_t wait_ms)
-{
+static inline bool ts_queue_enqueue(ts_queue_t *p_queue, void *p_item, uint32_t wait_ms) {
   struct timespec ts = {0};
   bool retval = false;
 
   clock_gettime(CLOCK_REALTIME, &ts);
-  if(wait_ms != WAIT_FOREVER) {
-    ts.tv_sec += wait_ms/1000;
+  if (wait_ms != WAIT_FOREVER) {
+    ts.tv_sec += wait_ms / 1000;
     ts.tv_nsec += ((long)wait_ms % 1000) * 1000000;
   }
-  if(p_queue && p_item) {
+  if (p_queue && p_item) {
     mutex_lock(&p_queue->mtx, WAIT_FOREVER);
     int rval = 0;
-    while(p_queue->tail + p_queue->size <= p_queue->head && rval != thrd_timedout) {
-      if(wait_ms == WAIT_FOREVER) {
+    while (p_queue->tail + p_queue->size <= p_queue->head && rval != thrd_timedout) {
+      if (wait_ms == WAIT_FOREVER) {
         rval = cnd_wait(&p_queue->full_cnd, &p_queue->mtx.mtx);
       } else {
         rval = cnd_timedwait(&p_queue->full_cnd, &p_queue->mtx.mtx, &ts);
       }
     }
-    if(rval != thrd_timedout) {
+    if (rval != thrd_timedout) {
       p_queue->pp_ptr_array[atomic_fetch_add(&p_queue->head, 1) & (p_queue->size - 1)] = p_item;
       p_queue->count++;
       cnd_signal(&p_queue->cnd);
@@ -128,30 +124,29 @@ static inline bool ts_queue_enqueue(ts_queue_t* p_queue, void* p_item, uint32_t 
   return retval;
 }
 
-static inline bool ts_queue_dequeue(ts_queue_t* p_queue, void** pp_item, uint32_t wait_ms)
-{
+static inline bool ts_queue_dequeue(ts_queue_t *p_queue, void **pp_item, uint32_t wait_ms) {
   bool retval = false;
   struct timespec ts = {0};
   clock_gettime(CLOCK_REALTIME, &ts);
 
-  if(wait_ms != WAIT_FOREVER) {
-    ts.tv_sec += wait_ms/1000;
+  if (wait_ms != WAIT_FOREVER) {
+    ts.tv_sec += wait_ms / 1000;
     ts.tv_nsec += ((long)wait_ms % 1000) * 1000000;
   }
-  if(p_queue && pp_item) {
+  if (p_queue && pp_item) {
     int rval = 0;
-    //This is always blocking because the mutex is only taken for non-blocking operations.
-    //Only the condition variable wait is timed, since there is no bound on how long it will
-    //take for an item to be enqueued onto the queue.
+    // This is always blocking because the mutex is only taken for non-blocking operations.
+    // Only the condition variable wait is timed, since there is no bound on how long it will
+    // take for an item to be enqueued onto the queue.
     mutex_lock(&p_queue->mtx, WAIT_FOREVER);
-    while(p_queue->tail >= p_queue->head && rval != thrd_timedout) {
-      if(wait_ms == WAIT_FOREVER) {
+    while (p_queue->tail >= p_queue->head && rval != thrd_timedout) {
+      if (wait_ms == WAIT_FOREVER) {
         rval = cnd_wait(&p_queue->cnd, &p_queue->mtx.mtx);
       } else {
         rval = cnd_timedwait(&p_queue->cnd, &p_queue->mtx.mtx, &ts);
       }
     }
-    if(rval == thrd_success) {
+    if (rval == thrd_success) {
       *pp_item = p_queue->pp_ptr_array[atomic_fetch_add(&p_queue->tail, 1) & (p_queue->size - 1)];
       p_queue->count--;
       cnd_signal(&p_queue->full_cnd);
@@ -162,13 +157,10 @@ static inline bool ts_queue_dequeue(ts_queue_t* p_queue, void** pp_item, uint32_
   return retval;
 }
 
-static inline size_t ts_queue_get_count(ts_queue_t* p_queue)
-{
-  return p_queue->count;
-}
+static inline size_t ts_queue_get_count(ts_queue_t *p_queue) { return p_queue->count; }
 
 #ifdef __cplusplus
 };
 #endif
 
-#endif //CUTILS_C11_TS_QUEUE_H
+#endif // CUTILS_C11_TS_QUEUE_H

--- a/inc/cutils/dispatch_queue.h
+++ b/inc/cutils/dispatch_queue.h
@@ -25,24 +25,22 @@
 #pragma once
 
 #include <cutils/os_types.h>
-#include <cutils/ts_queue.h>
-#include <cutils/task.h>
 #include <cutils/pool.h>
 #include <cutils/signal.h>
+#include <cutils/task.h>
+#include <cutils/ts_queue.h>
 #include <stdatomic.h>
 
-typedef struct _dispatch_queue_t
-{
+typedef struct _dispatch_queue_t {
   atomic_bool destroying;
   ts_queue_t *queue;
-  task_t* p_task;
+  task_t *p_task;
   pool_t *p_pool;
   char *label;
   signal_t signal;
 } dispatch_queue_t;
 
-typedef struct _dispatch_queue_create_params_t
-{
+typedef struct _dispatch_queue_create_params_t {
   dispatch_queue_t *p_queue;
   task_create_params_t task_params;
   pool_create_params_t pool_params;
@@ -50,57 +48,58 @@ typedef struct _dispatch_queue_create_params_t
 } dispatch_queue_create_params_t;
 
 /**
- * @brief Used internally to pass data asynchronously between the queue worker thread and the post routines
+ * @brief Used internally to pass data asynchronously between the queue worker thread and the post
+ * routines
  */
-typedef struct _dispatch_queue_post_data_t
-{
+typedef struct _dispatch_queue_post_data_t {
   dispatch_function_t fn;
-  void* arg1;
-  void* arg2;
-}dispatch_queue_post_data_t;
+  void *arg1;
+  void *arg2;
+} dispatch_queue_post_data_t;
 
-#define DISPATCH_QUEUE_STORE(name)  _dispatch_queue_##name
-#define DISPATCH_QUEUE_STORE_T(name)  dispatch_queue_store_##name##_t
+#define DISPATCH_QUEUE_STORE(name) _dispatch_queue_##name
+#define DISPATCH_QUEUE_STORE_T(name) dispatch_queue_store_##name##_t
 
-#define DISPATCH_QUEUE_STORE_DECL(name, queue_size, stack_size)\
-TASK_STATIC_STORE_DECL(dispatch_queue_##name, stack_size);\
-POOL_STORE_DECL(dispatch_queue_##name, queue_size, sizeof(dispatch_queue_post_data_t), 4);\
-TS_QUEUE_STORE_DECL(dispatch_queue_##name, queue_size);\
-typedef struct {\
-  dispatch_queue_t queue;\
-}DISPATCH_QUEUE_STORE_T(name)
+#define DISPATCH_QUEUE_STORE_DECL(name, queue_size, stack_size)                                    \
+  TASK_STATIC_STORE_DECL(dispatch_queue_##name, stack_size);                                       \
+  POOL_STORE_DECL(dispatch_queue_##name, queue_size, sizeof(dispatch_queue_post_data_t), 4);       \
+  TS_QUEUE_STORE_DECL(dispatch_queue_##name, queue_size);                                          \
+  typedef struct {                                                                                 \
+    dispatch_queue_t queue;                                                                        \
+  } DISPATCH_QUEUE_STORE_T(name)
 
-#define DISPATCH_QUEUE_STORE_DEF(name)\
-DISPATCH_QUEUE_STORE_T(name) DISPATCH_QUEUE_STORE(name);\
-TASK_STATIC_STORE_DEF(dispatch_queue_##name);\
-POOL_STORE_DEF(dispatch_queue_##name);\
-TS_QUEUE_STORE_DEF(dispatch_queue_##name)
+#define DISPATCH_QUEUE_STORE_DEF(name)                                                             \
+  DISPATCH_QUEUE_STORE_T(name) DISPATCH_QUEUE_STORE(name);                                         \
+  TASK_STATIC_STORE_DEF(dispatch_queue_##name);                                                    \
+  POOL_STORE_DEF(dispatch_queue_##name);                                                           \
+  TS_QUEUE_STORE_DEF(dispatch_queue_##name)
 
-#define DISPATCH_QUEUE_CREATE_PARAMS_INIT(params, name, task_name, pri)\
-memset(&(params), 0, sizeof(params));\
-(params).p_queue = &DISPATCH_QUEUE_STORE(name).queue;\
-TASK_STATIC_INIT_CREATE_PARAMS((params).task_params, dispatch_queue_##name, task_name, pri, NULL, NULL);\
-POOL_CREATE_INIT((params).pool_params, dispatch_queue_##name);\
-TS_QUEUE_STORE_CREATE_PARAMS_INIT((params).queue_params, dispatch_queue_##name)
-
+#define DISPATCH_QUEUE_CREATE_PARAMS_INIT(params, name, task_name, pri)                            \
+  memset(&(params), 0, sizeof(params));                                                            \
+  (params).p_queue = &DISPATCH_QUEUE_STORE(name).queue;                                            \
+  TASK_STATIC_INIT_CREATE_PARAMS(                                                                  \
+      (params).task_params, dispatch_queue_##name, task_name, pri, NULL, NULL);                    \
+  POOL_CREATE_INIT((params).pool_params, dispatch_queue_##name);                                   \
+  TS_QUEUE_STORE_CREATE_PARAMS_INIT((params).queue_params, dispatch_queue_##name)
 
 dispatch_queue_t *dispatch_queue_create(dispatch_queue_create_params_t *create_params);
 
 void dispatch_queue_destroy(dispatch_queue_t *p_queue);
 
 /**
- * @brief The function will post the dispatch_function_f callback onto the dispatch queue. The client can supply up to
- * two arguments. The client is responsible for object life time maintenance of the arguments supplied.
+ * @brief The function will post the dispatch_function_f callback onto the dispatch queue. The
+ * client can supply up to two arguments. The client is responsible for object life time maintenance
+ * of the arguments supplied.
  * @param p_queue - a successfully created dispatch_queue
  * @param fn - callback to be executed asynchronously
  * @param arg1 - client argument 1. Client maintains object lifecycle
  * @param arg2 - client argument 2. Client maintains object lifecycle
  * @return true if the action is posted on the queue. False otherwise. Indicates queue is destroyed.
  */
-static inline bool dispatch_async_f(dispatch_queue_t *p_queue, dispatch_function_t fn, void *arg1, void *arg2)
-{
+static inline bool
+dispatch_async_f(dispatch_queue_t *p_queue, dispatch_function_t fn, void *arg1, void *arg2) {
   bool retval = false;
-  if(p_queue && !atomic_load(&p_queue->destroying)){
+  if (p_queue && !atomic_load(&p_queue->destroying)) {
     dispatch_queue_post_data_t *p_data = pool_alloc(p_queue->p_pool);
     CUTILS_ASSERT(p_data);
     p_data->fn = fn;
@@ -112,11 +111,8 @@ static inline bool dispatch_async_f(dispatch_queue_t *p_queue, dispatch_function
   return retval;
 }
 
-bool dispatch_after_f(dispatch_queue_t *p_queue,
-                      uint32_t delay_ms,
-                      dispatch_function_t fn,
-                      void *arg1,
-                      void *arg2);
+bool dispatch_after_f(
+    dispatch_queue_t *p_queue, uint32_t delay_ms, dispatch_function_t fn, void *arg1, void *arg2);
 
 dispatch_queue_timed_action_h dispatch_start_repeated_f(dispatch_queue_t *p_queue,
                                                         uint32_t initial_ms,

--- a/inc/cutils/endian.h
+++ b/inc/cutils/endian.h
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 
-
 #pragma once
 
 #include <cutils/types.h>

--- a/inc/cutils/free_list.h
+++ b/inc/cutils/free_list.h
@@ -9,10 +9,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 
 #ifndef CUTILS_FREE_LIST_H
 #define CUTILS_FREE_LIST_H
@@ -34,47 +33,46 @@ extern "C" {
 
 typedef struct {
   KListHead *head;
-  void* data_store;
+  void *data_store;
   size_t item_size;
   size_t item_count;
   size_t current_available;
-}free_list_t;
+} free_list_t;
 
-#define FREE_LIST_STORE(name)  _free_list_store_##name
+#define FREE_LIST_STORE(name) _free_list_store_##name
 #define FREE_LIST_STORE_T(name) _free_list_store_##name##_t
-#define FREE_LIST_STORE_DECL(name, type, count)\
-typedef struct {\
-  type store[count];\
-  free_list_t list;\
-}FREE_LIST_STORE_T(name)
+#define FREE_LIST_STORE_DECL(name, type, count)                                                    \
+  typedef struct {                                                                                 \
+    type store[count];                                                                             \
+    free_list_t list;                                                                              \
+  } FREE_LIST_STORE_T(name)
 
-#define FREE_LIST_STORE_DEF(name)\
-FREE_LIST_STORE_T(name) FREE_LIST_STORE(name)
+#define FREE_LIST_STORE_DEF(name) FREE_LIST_STORE_T(name) FREE_LIST_STORE(name)
 
 typedef struct {
   free_list_t *list;
-  void* data_store;
+  void *data_store;
   size_t item_size;
   size_t item_count;
-}free_list_create_params_t;
+} free_list_create_params_t;
 
-#define FREE_LIST_STORE_CREATE_PARAMS_INIT(params, name)\
-(params).list = &FREE_LIST_STORE(name).list;\
-(params).data_store = (void*)FREE_LIST_STORE(name).store;\
-(params).item_size = sizeof(FREE_LIST_STORE(name).store[0]);\
-(params).item_count = GetArraySize(FREE_LIST_STORE(name).store);
+#define FREE_LIST_STORE_CREATE_PARAMS_INIT(params, name)                                           \
+  (params).list = &FREE_LIST_STORE(name).list;                                                     \
+  (params).data_store = (void *)FREE_LIST_STORE(name).store;                                       \
+  (params).item_size = sizeof(FREE_LIST_STORE(name).store[0]);                                     \
+  (params).item_count = GetArraySize(FREE_LIST_STORE(name).store);
 
-static inline free_list_t* free_list_init(free_list_create_params_t *p_params)
-{
+static inline free_list_t *free_list_init(free_list_create_params_t *p_params) {
   free_list_t *retval = 0;
-  if(p_params->list && p_params->data_store && p_params->item_size > 0) {
+  if (p_params->list && p_params->data_store && p_params->item_size > 0) {
     p_params->list->data_store = p_params->data_store;
     p_params->list->item_size = p_params->item_size;
     p_params->list->item_count = p_params->item_count;
     p_params->list->head = 0;
     p_params->list->current_available = 0;
-    for(size_t i = 0; i < p_params->item_count; i++) {
-      KLIST_HEAD_PREPEND(p_params->list->head, ((char*)p_params->data_store + (p_params->item_size * i)));
+    for (size_t i = 0; i < p_params->item_count; i++) {
+      KLIST_HEAD_PREPEND(p_params->list->head,
+                         ((char *)p_params->data_store + (p_params->item_size * i)));
       p_params->list->current_available++;
     }
     retval = p_params->list;
@@ -82,20 +80,18 @@ static inline free_list_t* free_list_init(free_list_create_params_t *p_params)
   return retval;
 }
 
-static inline KListElem* free_list_get(free_list_t *list)
-{
+static inline KListElem *free_list_get(free_list_t *list) {
   KListElem *item = 0;
-  if(list->head && list->current_available > 0) {
+  if (list->head && list->current_available > 0) {
     KLIST_HEAD_POP(list->head, item);
     list->current_available--;
   }
   return item;
 }
 
-static inline bool free_list_put(free_list_t* list, KListElem *item)
-{
+static inline bool free_list_put(free_list_t *list, KListElem *item) {
   bool retval = false;
-  if(list && list->current_available < list->item_count) {
+  if (list && list->current_available < list->item_count) {
     KLIST_HEAD_PREPEND(list->head, item);
     list->current_available++;
     retval = true;
@@ -106,4 +102,4 @@ static inline bool free_list_put(free_list_t* list, KListElem *item)
 #ifdef __cplusplus
 };
 #endif
-#endif //CUTILS_FREE_LIST_H
+#endif // CUTILS_FREE_LIST_H

--- a/inc/cutils/klist.h
+++ b/inc/cutils/klist.h
@@ -41,104 +41,124 @@ extern "C" {
  **/
 
 /**
- * @struct KListElem - Sentinel for all elements that wish to be 
+ * @struct KListElem - Sentinel for all elements that wish to be
  *         added to a list.
- *  
- * This holds the next and prev pointers. All data structures 
- * that need to be added to a list must have this as its first 
- * element. Thus if you want to put some arbitrary data into a 
- * KList, you need to encapsulate it in a data structure with 
- * KListElem being its first member and then use instances of 
- * that structure to insert. 
+ *
+ * This holds the next and prev pointers. All data structures
+ * that need to be added to a list must have this as its first
+ * element. Thus if you want to put some arbitrary data into a
+ * KList, you need to encapsulate it in a data structure with
+ * KListElem being its first member and then use instances of
+ * that structure to insert.
  */
-typedef struct _KListElem
-{
+typedef struct _KListElem {
   struct _KListElem *prev;
   struct _KListElem *next;
 } KListElem, KListHead, KListTail;
 
 /**
- * Callback that is executed on every element of a List when 
+ * Callback that is executed on every element of a List when
  * called using KLIST_HEAD_FOREACH
  */
-typedef void (*KListForEachCb) (KListElem * pElem, ...);
-typedef bool(*KListFindPredicate) (KListElem * pElem, ...);
+typedef void (*KListForEachCb)(KListElem *pElem, ...);
+typedef bool (*KListFindPredicate)(KListElem *pElem, ...);
 
-#define KLIST_HEAD_INIT( pHead )     do { if( (pHead) ){ (pHead)->prev = (pHead)->next = 0; } }while(0)
-#define KLIST_HEAD_FOREACH( pHead, fnHandler, handlerArgs... )  do {\
-                                                  KListElem *pElem = (pHead);\
-                                                  while( pElem ) {\
-                                                    KListElem *pNext = pElem->next;\
-                                                    fnHandler( pElem, ##handlerArgs );\
-                                                    pElem = pNext;\
-                                                  }\
-                                                }while( 0 )
-#define KLIST_HEAD_FIND_FIRST( pHead, pRetElem, fnHandler, handlerArgs... ) do\
-                                                  {\
-                                                    KListElem *pElem = (pHead);\
-                                                    while( pElem ) {\
-                                                      KListElem* pNext = pElem->next;\
-                                                      if( fnHandler( pElem, ##handlerArgs ) ) {\
-                                                        pRetElem = pElem;\
-                                                        break;\
-                                                      }\
-                                                      pElem = pNext;\
-                                                    }\
-                                                  }while(0)
-#define KLIST_HEAD_PREPEND( pHead, pItem ) do { \
-                                              if( (pItem) ) {\
-                                                if( (pHead) ) {\
-                                                  (pHead)->prev = ( KListElem* )(pItem);\
-                                                  ( ( KListElem* ) (pItem) )->prev = 0;\
-                                                  ( ( KListElem* ) (pItem) )->next = (pHead);\
-                                                }\
-                                                (pHead) = ( KListHead *)(pItem);\
-                                              }\
-                                             }while( 0 )
-#define KLIST_HEAD_POP( pHead, pItem )    do { \
-                                             if( (pHead) ) { \
-                                               KListElem** ppElem = ( ( KListElem** ) &(pItem) );\
-                                               *ppElem = (pHead);\
-                                               (pHead) = (pHead)->next;\
-                                               ( *ppElem )->next = ( *ppElem )->prev = 0;\
-                                             }\
-                                             else (pItem) = 0;\
-                                          }while( 0 )
-#define KLIST_TAIL_INIT( pTail )      do { if( (pTail) ) { (pTail)->prev = (pTail)->next = 0; } }while( 0 )
+#define KLIST_HEAD_INIT(pHead)                                                                     \
+  do {                                                                                             \
+    if ((pHead)) {                                                                                 \
+      (pHead)->prev = (pHead)->next = 0;                                                           \
+    }                                                                                              \
+  } while (0)
+#define KLIST_HEAD_FOREACH(pHead, fnHandler, handlerArgs...)                                       \
+  do {                                                                                             \
+    KListElem *pElem = (pHead);                                                                    \
+    while (pElem) {                                                                                \
+      KListElem *pNext = pElem->next;                                                              \
+      fnHandler(pElem, ##handlerArgs);                                                             \
+      pElem = pNext;                                                                               \
+    }                                                                                              \
+  } while (0)
+#define KLIST_HEAD_FIND_FIRST(pHead, pRetElem, fnHandler, handlerArgs...)                          \
+  do {                                                                                             \
+    KListElem *pElem = (pHead);                                                                    \
+    while (pElem) {                                                                                \
+      KListElem *pNext = pElem->next;                                                              \
+      if (fnHandler(pElem, ##handlerArgs)) {                                                       \
+        pRetElem = pElem;                                                                          \
+        break;                                                                                     \
+      }                                                                                            \
+      pElem = pNext;                                                                               \
+    }                                                                                              \
+  } while (0)
+#define KLIST_HEAD_PREPEND(pHead, pItem)                                                           \
+  do {                                                                                             \
+    if ((pItem)) {                                                                                 \
+      if ((pHead)) {                                                                               \
+        (pHead)->prev = (KListElem *)(pItem);                                                      \
+        ((KListElem *)(pItem))->prev = 0;                                                          \
+        ((KListElem *)(pItem))->next = (pHead);                                                    \
+      }                                                                                            \
+      (pHead) = (KListHead *)(pItem);                                                              \
+    }                                                                                              \
+  } while (0)
+#define KLIST_HEAD_POP(pHead, pItem)                                                               \
+  do {                                                                                             \
+    if ((pHead)) {                                                                                 \
+      KListElem **ppElem = ((KListElem **)&(pItem));                                               \
+      *ppElem = (pHead);                                                                           \
+      (pHead) = (pHead)->next;                                                                     \
+      (*ppElem)->next = (*ppElem)->prev = 0;                                                       \
+    } else                                                                                         \
+      (pItem) = 0;                                                                                 \
+  } while (0)
+#define KLIST_TAIL_INIT(pTail)                                                                     \
+  do {                                                                                             \
+    if ((pTail)) {                                                                                 \
+      (pTail)->prev = (pTail)->next = 0;                                                           \
+    }                                                                                              \
+  } while (0)
 
-#define KLIST_TAIL_APPEND( pTail, pItem )  do{\
-                                             if( (pItem) ) {\
-                                               if( (pTail) ) {\
-                                                 (pTail)->next = ( KListElem* )(pItem);\
-                                                 ( ( KListElem* ) (pItem) )->next = 0;\
-                                                 ( ( KListElem* ) (pItem) )->prev = (pTail);\
-                                               }\
-                                               (pTail) = ( KListTail* )(pItem);\
-                                             }\
-                                           }while( 0 )
+#define KLIST_TAIL_APPEND(pTail, pItem)                                                            \
+  do {                                                                                             \
+    if ((pItem)) {                                                                                 \
+      if ((pTail)) {                                                                               \
+        (pTail)->next = (KListElem *)(pItem);                                                      \
+        ((KListElem *)(pItem))->next = 0;                                                          \
+        ((KListElem *)(pItem))->prev = (pTail);                                                    \
+      }                                                                                            \
+      (pTail) = (KListTail *)(pItem);                                                              \
+    }                                                                                              \
+  } while (0)
 
-#define KLIST_REMOVE_ELEM( pElem )   do { \
-                                        KListElem *pEl = ( KListElem * )(pElem);\
-                                        if( pEl ){\
-                                          if( pEl->next ) { pEl->next->prev = pEl->prev; }\
-                                          if( pEl->prev ) { pEl->prev->next = pEl->next; }\
-                                          pEl->next = pEl->prev = 0;\
-                                        }\
-                                     }while( 0 )
+#define KLIST_REMOVE_ELEM(pElem)                                                                   \
+  do {                                                                                             \
+    KListElem *pEl = (KListElem *)(pElem);                                                         \
+    if (pEl) {                                                                                     \
+      if (pEl->next) {                                                                             \
+        pEl->next->prev = pEl->prev;                                                               \
+      }                                                                                            \
+      if (pEl->prev) {                                                                             \
+        pEl->prev->next = pEl->next;                                                               \
+      }                                                                                            \
+      pEl->next = pEl->prev = 0;                                                                   \
+    }                                                                                              \
+  } while (0)
 
-#define KLIST_HEAD_REMOVE_ELEM( pHead, pElem ) do {\
-                                      if( ( KListHead* )(pHead) == ( KListElem* )(pElem) ) {\
-                                        (pHead) = ( (KListElem*)(pElem) )->next;\
-                                      }\
-                                      KLIST_REMOVE_ELEM( (pElem) );\
-                                    }while( 0 )
+#define KLIST_HEAD_REMOVE_ELEM(pHead, pElem)                                                       \
+  do {                                                                                             \
+    if ((KListHead *)(pHead) == (KListElem *)(pElem)) {                                            \
+      (pHead) = ((KListElem *)(pElem))->next;                                                      \
+    }                                                                                              \
+    KLIST_REMOVE_ELEM((pElem));                                                                    \
+  } while (0)
 
-#define KLIST_TAIL_REMOVE_ELEM( pTail, pElem ) do {\
-                                      if( ( KListTail* )(pTail) == ( KListElem* )(pElem) ) {\
-                                        (pTail) = ( (KListElem*)(pElem) )->prev;\
-                                      }\
-                                      KLIST_REMOVE_ELEM( pElem );\
-                                    }while( 0 )
+#define KLIST_TAIL_REMOVE_ELEM(pTail, pElem)                                                       \
+  do {                                                                                             \
+    if ((KListTail *)(pTail) == (KListElem *)(pElem)) {                                            \
+      (pTail) = ((KListElem *)(pElem))->prev;                                                      \
+    }                                                                                              \
+    KLIST_REMOVE_ELEM(pElem);                                                                      \
+  } while (0)
 
 #ifdef __cplusplus
 }

--- a/inc/cutils/kqueue.h
+++ b/inc/cutils/kqueue.h
@@ -30,21 +30,19 @@
 extern "C" {
 #endif
 
+typedef bool (*kqueue_find_predicate_f)(KListElem *pElem, va_list argList);
 
-typedef bool (*kqueue_find_predicate_f)(KListElem *pElem, va_list argList );
-
-typedef void (*kqueue_drop_f)(KListElem* pElem );
+typedef void (*kqueue_drop_f)(KListElem *pElem);
 /**
  * @struct KQueue - a Queue implementation based on KList.
  * This is not thread safe.
  */
-typedef struct _kqueue_t
-{
+typedef struct _kqueue_t {
   KListHead *p_head;
   KListTail *p_tail;
   kqueue_drop_f f_drop;
   uint32_t item_count;
-}kqueue_t;
+} kqueue_t;
 
 /**
  * @fn kqueue_init - Initializes the Queue.
@@ -52,9 +50,8 @@ typedef struct _kqueue_t
  *
  * @param pQueue - Allocated Queue owned by client.
  */
-static inline void kqueue_init(kqueue_t* pQueue )
-{
-  if ( pQueue ) {
+static inline void kqueue_init(kqueue_t *pQueue) {
+  if (pQueue) {
     pQueue->p_head = pQueue->p_tail = 0;
     pQueue->f_drop = 0;
     pQueue->item_count = 0;
@@ -69,10 +66,9 @@ static inline void kqueue_init(kqueue_t* pQueue )
  *
  * @return bool - true if empty.
  */
-static inline bool kqueue_is_empty(kqueue_t *pQueue )
-{
+static inline bool kqueue_is_empty(kqueue_t *pQueue) {
   bool retval = true;
-  if (pQueue && pQueue->p_head != 0 && pQueue->p_tail != 0 ) {
+  if (pQueue && pQueue->p_head != 0 && pQueue->p_tail != 0) {
     retval = false;
   }
   return retval;
@@ -85,11 +81,10 @@ static inline bool kqueue_is_empty(kqueue_t *pQueue )
  * @param p_queue - Allocated and initialized queue.
  * @param p_elem - element to insert.
  */
-static inline void kqueue_insert(kqueue_t *p_queue, KListElem *p_elem )
-{
-  if (p_queue && p_elem ) {
-    KLIST_TAIL_APPEND(p_queue->p_tail, p_elem );
-    if (p_queue->p_head == 0 ) {
+static inline void kqueue_insert(kqueue_t *p_queue, KListElem *p_elem) {
+  if (p_queue && p_elem) {
+    KLIST_TAIL_APPEND(p_queue->p_tail, p_elem);
+    if (p_queue->p_head == 0) {
       p_queue->p_head = p_queue->p_tail;
     }
     p_queue->item_count++;
@@ -105,17 +100,16 @@ static inline void kqueue_insert(kqueue_t *p_queue, KListElem *p_elem )
  *
  * @return KListElem* - Element that has been dequeued.
  */
-static inline KListElem* kqueue_dequeue(kqueue_t *p_queue )
-{
+static inline KListElem *kqueue_dequeue(kqueue_t *p_queue) {
   KListElem *p_item = 0;
-  if ( !kqueue_is_empty(p_queue) ) {
-    if (p_queue->p_head == p_queue->p_tail ) {
-      //Only one element
+  if (!kqueue_is_empty(p_queue)) {
+    if (p_queue->p_head == p_queue->p_tail) {
+      // Only one element
       p_queue->p_tail = 0;
     }
     p_item = p_queue->p_head;
     p_queue->p_head = p_item->next;
-    KLIST_REMOVE_ELEM(p_item );
+    KLIST_REMOVE_ELEM(p_item);
     p_queue->item_count--;
   }
   return p_item;
@@ -132,9 +126,8 @@ static inline KListElem* kqueue_dequeue(kqueue_t *p_queue )
  * @param pQueue
  * @param cb
  */
-static inline void kqueue_register_drop_all_cb(kqueue_t* pQueue, kqueue_drop_f cb )
-{
-  if ( pQueue ) {
+static inline void kqueue_register_drop_all_cb(kqueue_t *pQueue, kqueue_drop_f cb) {
+  if (pQueue) {
     pQueue->f_drop = cb;
   }
 }
@@ -148,13 +141,12 @@ static inline void kqueue_register_drop_all_cb(kqueue_t* pQueue, kqueue_drop_f c
  *
  * @param p_queue
  */
-static inline void kqueue_drop_all(kqueue_t *p_queue )
-{
-  KListElem *pElem= 0;
-  while( !kqueue_is_empty(p_queue) ) {
+static inline void kqueue_drop_all(kqueue_t *p_queue) {
+  KListElem *pElem = 0;
+  while (!kqueue_is_empty(p_queue)) {
     pElem = kqueue_dequeue(p_queue);
-    if ( p_queue->f_drop ) {
-      p_queue->f_drop(pElem );
+    if (p_queue->f_drop) {
+      p_queue->f_drop(pElem);
     }
   }
 }
@@ -167,26 +159,24 @@ static inline void kqueue_drop_all(kqueue_t *p_queue )
  * @param p_queue
  * @param f_find
  */
-static inline KListElem* kqueue_find_first(kqueue_t* p_queue, kqueue_find_predicate_f f_find, ... )
-{
+static inline KListElem *kqueue_find_first(kqueue_t *p_queue, kqueue_find_predicate_f f_find, ...) {
   va_list argList;
-  va_start(argList, f_find );
-  KListElem* pRetVal = 0;
+  va_start(argList, f_find);
+  KListElem *pRetVal = 0;
 
   KListElem *pElem = p_queue->p_head;
-  while( pElem ) {
-    KListElem* pNext = pElem->next;
-    if( f_find(pElem, argList ) ) {
+  while (pElem) {
+    KListElem *pNext = pElem->next;
+    if (f_find(pElem, argList)) {
       pRetVal = pElem;
       break;
     }
     pElem = pNext;
   }
 
-  va_end( argList );
+  va_end(argList);
   return pRetVal;
 }
-
 
 /**
  * @fn kqueue_drop_all_through_elem - Delete all elements from head through
@@ -195,19 +185,18 @@ static inline KListElem* kqueue_find_first(kqueue_t* p_queue, kqueue_find_predic
  * @param p_queue
  * @param p_elem
  */
-static inline void kqueue_drop_all_through_elem(kqueue_t *p_queue, KListElem *p_elem )
-{
-  KListElem *pDequeue= 0;
-  while( true ) {
+static inline void kqueue_drop_all_through_elem(kqueue_t *p_queue, KListElem *p_elem) {
+  KListElem *pDequeue = 0;
+  while (true) {
     pDequeue = kqueue_dequeue(p_queue);
-    if ( !pDequeue ) {
+    if (!pDequeue) {
       // reached end of list without finding anything just break
       break;
-    } else if (p_elem == pDequeue ) {
-      p_queue->f_drop(pDequeue );
+    } else if (p_elem == pDequeue) {
+      p_queue->f_drop(pDequeue);
       break;
     } else {
-      p_queue->f_drop(pDequeue );
+      p_queue->f_drop(pDequeue);
     }
   }
 }
@@ -219,10 +208,9 @@ static inline void kqueue_drop_all_through_elem(kqueue_t *p_queue, KListElem *p_
  * @param p_queue - pointer to a Valid initialized Queue
  * @return uint32_t - number of elements in queue.
  */
-static inline uint32_t kqueue_get_item_count(kqueue_t* p_queue )
-{
+static inline uint32_t kqueue_get_item_count(kqueue_t *p_queue) {
   uint32_t count = 0;
-  if( p_queue ) {
+  if (p_queue) {
     count = p_queue->item_count;
   }
   return count;
@@ -232,4 +220,4 @@ static inline uint32_t kqueue_get_item_count(kqueue_t* p_queue )
 }
 #endif
 
-#endif //CUTILS_KQUEUE_H
+#endif // CUTILS_KQUEUE_H

--- a/inc/cutils/log_buffer.h
+++ b/inc/cutils/log_buffer.h
@@ -26,17 +26,15 @@
 
 #include <cutils/types.h>
 
-
 /**
- *  @file LogBuffer 
+ *  @file LogBuffer
  *  This Ring Buffer works for 1 byte characters to be used to
  *  capture logging.
- *  
- * 
+ *
+ *
  */
 
-typedef struct _LogBuffer
-{
+typedef struct _LogBuffer {
   char *p_buffer;
   bool isInit;
   uint32_t bufferSize;
@@ -45,40 +43,40 @@ typedef struct _LogBuffer
 } log_buffer_t;
 
 /**
- * LogBufferInit - Initializes the ring buffer. 
- * 
+ * LogBufferInit - Initializes the ring buffer.
+ *
  * \param pLb - Provide a valid Ring Buffer but don't fill it up
  * \param pBuffer - A backing store for the ring buffer
- * \param bufferSize - The total size of the backing buffer 
+ * \param bufferSize - The total size of the backing buffer
  */
 bool log_buffer_init(log_buffer_t *pLb, char *pBuffer, uint32_t bufferSize);
 
 /**
- * LogBufferPush - This will push the string character by 
- * character into the Log Buffer. 
- * 
- * \param pLb - Pointer to intialized Log Buffer 
- * \param pString - pString. 
+ * LogBufferPush - This will push the string character by
+ * character into the Log Buffer.
+ *
+ * \param pLb - Pointer to intialized Log Buffer
+ * \param pString - pString.
  * \param stringSize - string size as determined by strlen()
- * 
- * \return bool - true if successful 
+ *
+ * \return bool - true if successful
  */
 bool log_buffer_push(log_buffer_t *pLb, char *pString, uint32_t stringSize);
 
 /**
- * LogBufferIsEmpty - Returns true if the log buffer is empty. 
- *  
- * 
- * \param pLb 
- * 
- * \return bool 
+ * LogBufferIsEmpty - Returns true if the log buffer is empty.
+ *
+ *
+ * \param pLb
+ *
+ * \return bool
  */
 bool log_buffer_is_empty(log_buffer_t *pLb);
 
 /**
  * LogBufferCharPop - Pops the character at the tail of the log buffer.
  * Returns true for a successful read and false if the Log buffer is empty.
- * 
+ *
  * \param pLb - pointer to valid Log Buffer
  * \param pChar - pointer to character which will contain popped value
  * \return bool - false if log buffer is empty or invalid inputs.
@@ -87,15 +85,13 @@ bool log_buffer_char_pop(log_buffer_t *pLb, int8_t *pChar);
 
 /**
  * LogBufferClear - Resets the Log buffer. Data is not invalidated but all pointers
- * are reset and the data will be overwritten. 
- * 
+ * are reset and the data will be overwritten.
+ *
  * \param pLb - pointer to valid Log Buffer
  */
 void log_buffer_clear(log_buffer_t *pLb);
 
-uint32_t log_buffer_current_size(log_buffer_t *pLb,
-                                 uint32_t *initial_chunk,
-                                 uint32_t *residue_bytes);
-
+uint32_t
+log_buffer_current_size(log_buffer_t *pLb, uint32_t *initial_chunk, uint32_t *residue_bytes);
 
 uint32_t log_buffer_lines_from_size(uint32_t size);

--- a/inc/cutils/logger.h
+++ b/inc/cutils/logger.h
@@ -2,58 +2,54 @@
 #pragma once
 
 #include <cutils/types.h>
-#include <stdio.h>
-#include <stddef.h>
 #include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef struct _Logger
-{
+typedef struct _Logger {
   uint32_t (*fnPrefix)(struct _Logger *, void *pPrivate, char *pString, uint32_t stringSize);
 
   bool isEnabled;
   uint32_t log_level;
 } logger_t;
 
-typedef struct _SimpleLogger
-{
+typedef struct _SimpleLogger {
   logger_t base;
   char *pPrefix;
 } simple_logger_t;
 
-uint32_t SimpleLoggerPrefix(logger_t *p_logger, void *p_private, char *p_string, uint32_t string_size);
+uint32_t
+SimpleLoggerPrefix(logger_t *p_logger, void *p_private, char *p_string, uint32_t string_size);
 
-#define SIMPLE_LOGGER_DECL(name) \
-simple_logger_t sysLog_##name
+#define SIMPLE_LOGGER_DECL(name) simple_logger_t sysLog_##name
 
-#define SIMPLE_LOGGER_DEF(name, prefix, enabled)\
-simple_logger_t sysLog_##name = { .base.isEnabled = (enabled),\
-  .base.fnPrefix = SimpleLoggerPrefix,\
-  .base.log_level = 0,\
-  .pPrefix = (prefix),\
-}
+#define SIMPLE_LOGGER_DEF(name, prefix, enabled)                                                   \
+  simple_logger_t sysLog_##name = {                                                                \
+      .base.isEnabled = (enabled),                                                                 \
+      .base.fnPrefix = SimpleLoggerPrefix,                                                         \
+      .base.log_level = 0,                                                                         \
+      .pPrefix = (prefix),                                                                         \
+  }
 
-#define SIMPLE_LOGGER_STRUCT_INIT(name, prefix, enabled)\
-sysLog_##name = {\
-  .base.isEnabled = (enabled),\
-  .base.fnPrefix = SimpleLoggerPrefix,\
-  .base.log_level = 0,\
-  .pPrefix = (prefix)\
-}
+#define SIMPLE_LOGGER_STRUCT_INIT(name, prefix, enabled)                                           \
+  sysLog_##name = {.base.isEnabled = (enabled),                                                    \
+                   .base.fnPrefix = SimpleLoggerPrefix,                                            \
+                   .base.log_level = 0,                                                            \
+                   .pPrefix = (prefix)}
 
-#define SIMPLE_LOGGER_INIT(logger, prefix, enabled)\
-{\
-  (logger)->base.isEnabled = (enabled);\
-  (logger)->base.fnPrefix = SimpleLoggerPrefix;\
-  (logger)->base.log_level = 0;\
-  (logger)->pPrefix = prefix;\
-}
+#define SIMPLE_LOGGER_INIT(logger, prefix, enabled)                                                \
+  {                                                                                                \
+    (logger)->base.isEnabled = (enabled);                                                          \
+    (logger)->base.fnPrefix = SimpleLoggerPrefix;                                                  \
+    (logger)->base.log_level = 0;                                                                  \
+    (logger)->pPrefix = prefix;                                                                    \
+  }
 
-static inline simple_logger_t simple_logger_init(char *prefix, bool enabled)
-{
+static inline simple_logger_t simple_logger_init(char *prefix, bool enabled) {
   simple_logger_t logger;
 
   logger.base.isEnabled = enabled;
@@ -69,7 +65,10 @@ extern SIMPLE_LOGGER_DECL(general_logger);
 
 uint32_t logger_write_string(logger_t *p_logger,
                              void *p_private,
-                             const char *fmt, char *p_buffer, uint32_t buffer_size, va_list args);
+                             const char *fmt,
+                             char *p_buffer,
+                             uint32_t buffer_size,
+                             va_list args);
 
 void console_log(logger_t *logger, void *p_private, char *str, ...);
 
@@ -79,59 +78,83 @@ void console_log_raw(char *str, ...);
  * Can be used to build up a string.
  * Initialize n_written to zero on the first call
  */
-#define INSERT_TO_STRING(p_str, n_written, fmt, ...)\
-do{\
-  int res = sprintf( p_str + n_written, fmt, ##__VA_ARGS__ );\
-  n_written += (res > 0) ? res : 0;\
-}while(0)
+#define INSERT_TO_STRING(p_str, n_written, fmt, ...)                                               \
+  do {                                                                                             \
+    int res = sprintf(p_str + n_written, fmt, ##__VA_ARGS__);                                      \
+    n_written += (res > 0) ? res : 0;                                                              \
+  } while (0)
 
-#define CLOG(str, ...)   console_log( &SIMPLE_LOGGER( general_logger ).base, NULL,(char*)"%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__ )
-#define CHECK_RETURN(expr, retval) if( !(expr) ) { CLOG( #expr " failed " ); return retval; }
-#define CHECK_RETURNF(expr, retval, str, ...) if(!(expr)) { CLOG( #expr " failed - " str, ##__VA_ARGS__ ); return retval;}
-#define CHECK_RUN(expr, run_lines, str, ...) if(!(expr)) { CLOG( #expr " failed - " str, ##__VA_ARGS__); run_lines; }
+#define CLOG(str, ...)                                                                             \
+  console_log(&SIMPLE_LOGGER(general_logger).base,                                                 \
+              NULL,                                                                                \
+              (char *)"%s(%u): " str,                                                              \
+              __FUNCTION__,                                                                        \
+              __LINE__,                                                                            \
+              ##__VA_ARGS__)
+#define CHECK_RETURN(expr, retval)                                                                 \
+  if (!(expr)) {                                                                                   \
+    CLOG(#expr " failed ");                                                                        \
+    return retval;                                                                                 \
+  }
+#define CHECK_RETURNF(expr, retval, str, ...)                                                      \
+  if (!(expr)) {                                                                                   \
+    CLOG(#expr " failed - " str, ##__VA_ARGS__);                                                   \
+    return retval;                                                                                 \
+  }
+#define CHECK_RUN(expr, run_lines, str, ...)                                                       \
+  if (!(expr)) {                                                                                   \
+    CLOG(#expr " failed - " str, ##__VA_ARGS__);                                                   \
+    run_lines;                                                                                     \
+  }
 
-#define CLOG_IF(cond, str, ...);  { if( (cond) ) CLOG( str, ##__VA_ARGS__ ); }
-#define LOG_IF(LOGGER_MACRO, cond, str, ...); { if( (cond) ) LOGGER_MACRO(str, ##__VA_ARGS__ ); }
+#define CLOG_IF(cond, str, ...)                                                                    \
+  ;                                                                                                \
+  {                                                                                                \
+    if ((cond))                                                                                    \
+      CLOG(str, ##__VA_ARGS__);                                                                    \
+  }
+#define LOG_IF(LOGGER_MACRO, cond, str, ...)                                                       \
+  ;                                                                                                \
+  {                                                                                                \
+    if ((cond))                                                                                    \
+      LOGGER_MACRO(str, ##__VA_ARGS__);                                                            \
+  }
 
-#define LOG_FIELD(x, f, MACRO)    MACRO(#x " = %" #f, x)
-#define CLOG_FIELD(x, f)    LOG_FIELD( #x " = %" #f, x, CLOG)
+#define LOG_FIELD(x, f, MACRO) MACRO(#x " = %" #f, x)
+#define CLOG_FIELD(x, f) LOG_FIELD(#x " = %" #f, x, CLOG)
 
 /* NOTE: Compute the microseconds elapsed for a given function.
 AmbaUtility_HighResolutionTimerStart() needs to be called somewhere earlier. */
-#define TIMED_FUNC_US(retval, func, ...)\
-{\
-  UINT64 func##_start, func##_end;\
-  AmbaUtility_GetHighResolutionTimeStamp(&func##_start);\
-  func(__VA_ARGS__);\
-  AmbaUtility_GetHighResolutionTimeStamp(&func##_end);\
-  retval = func##_end - func##_start;\
-}
+#define TIMED_FUNC_US(retval, func, ...)                                                           \
+  {                                                                                                \
+    UINT64 func##_start, func##_end;                                                               \
+    AmbaUtility_GetHighResolutionTimeStamp(&func##_start);                                         \
+    func(__VA_ARGS__);                                                                             \
+    AmbaUtility_GetHighResolutionTimeStamp(&func##_end);                                           \
+    retval = func##_end - func##_start;                                                            \
+  }
 
 /* NOTE: Compute the milliseconds elapsed for a given function. */
-#define TIMED_FUNC_MS(retval, func, ...)\
-{\
-  uint32_t func##_start = task_get_ticks();\
-  func(__VA_ARGS__);\
-  retval = task_get_ticks() - func##_start;\
-}
+#define TIMED_FUNC_MS(retval, func, ...)                                                           \
+  {                                                                                                \
+    uint32_t func##_start = task_get_ticks();                                                      \
+    func(__VA_ARGS__);                                                                             \
+    retval = task_get_ticks() - func##_start;                                                      \
+  }
 
 #define BYTE_TO_BINARY_PATTERN "%c%c%c%c%c%c%c%c"
-#define BYTE_TO_BINARY(byte)  \
-  ((byte) & 0x80 ? '1' : '0'), \
-  ((byte) & 0x40 ? '1' : '0'), \
-  ((byte) & 0x20 ? '1' : '0'), \
-  ((byte) & 0x10 ? '1' : '0'), \
-  ((byte) & 0x08 ? '1' : '0'), \
-  ((byte) & 0x04 ? '1' : '0'), \
-  ((byte) & 0x02 ? '1' : '0'), \
-  ((byte) & 0x01 ? '1' : '0')
+#define BYTE_TO_BINARY(byte)                                                                       \
+  ((byte) & 0x80 ? '1' : '0'), ((byte) & 0x40 ? '1' : '0'), ((byte) & 0x20 ? '1' : '0'),           \
+      ((byte) & 0x10 ? '1' : '0'), ((byte) & 0x08 ? '1' : '0'), ((byte) & 0x04 ? '1' : '0'),       \
+      ((byte) & 0x02 ? '1' : '0'), ((byte) & 0x01 ? '1' : '0')
 
-#define CUTILS_ASSERTF(cnd, str, ...) {\
-  if(!(cnd)) {\
-    CLOG(#cnd " Assertion failed @ %s line %u: " str, __FILE__, __LINE__, ##__VA_ARGS__);\
-    *((volatile char*)0) =1;\
-  }\
-}
+#define CUTILS_ASSERTF(cnd, str, ...)                                                              \
+  {                                                                                                \
+    if (!(cnd)) {                                                                                  \
+      CLOG(#cnd " Assertion failed @ %s line %u: " str, __FILE__, __LINE__, ##__VA_ARGS__);        \
+      *((volatile char *)0) = 1;                                                                   \
+    }                                                                                              \
+  }
 
 #ifdef __cplusplus
 };

--- a/inc/cutils/notifier.h
+++ b/inc/cutils/notifier.h
@@ -24,36 +24,35 @@
 
 #pragma once
 
-#include <cutils/types.h>
+#include <cutils/klist.h>
 #include <cutils/logger.h>
 #include <cutils/mutex.h>
-#include <cutils/klist.h>
 #include <cutils/pool.h>
+#include <cutils/types.h>
 
 /**
  * @file Notifier.h
  * @brief Category specific notifier.
- *   
+ *
  *  The Notifier API provides a way to store Notification
  *  callbacks for different types of notifications. A table of
  *  Notification callbacks is maintained. THe Table is indexed
  *  by the notification type and the value is alist of
  *  callbacks. When a notification is posted, the callbacks in
- *  the corresponding list are called one by one. 
+ *  the corresponding list are called one by one.
  */
 
 /**
  * @struct NotifierBlock
- *  
+ *
  * @brief Different Notifications should use this as the first
  *        element in their notification data structure.
- *  
- * This is used to queue notifications into the lists 
- * internally. This is meant to be used by a client that want to 
- * offer specific notifications for events that it handles. 
+ *
+ * This is used to queue notifications into the lists
+ * internally. This is meant to be used by a client that want to
+ * offer specific notifications for events that it handles.
  */
-typedef struct
-{
+typedef struct {
   KListElem elem;
   uint32_t category;
 } notifier_block_t;
@@ -61,9 +60,9 @@ typedef struct
 /**
  * @fn notifier_f
  * @brief callback for a specific notification.
- *  
- * Clients can register callbacks of this type. 
- *  
+ *
+ * Clients can register callbacks of this type.
+ *
  * @param pBlock - The Notification that was posted will be
  *        called
  * @param category - the notification type that is used as a key
@@ -71,14 +70,13 @@ typedef struct
  * @param pNotificationData - any private data that is posted in
  *        the notification
  */
-typedef void (*notifier_f) (notifier_block_t * pBlock, uint32_t category, void *pNotificationData);
+typedef void (*notifier_f)(notifier_block_t *pBlock, uint32_t category, void *pNotificationData);
 
 /**
- * This is the basic Notifier data structure that clients that 
- * want to expose a notification system, must initialize. 
+ * This is the basic Notifier data structure that clients that
+ * want to expose a notification system, must initialize.
  */
-typedef struct _notifier_t
-{
+typedef struct _notifier_t {
   mutex_t mtx;
   KListHead **notif_array;
   uint32_t total_notification_categories;
@@ -88,108 +86,110 @@ typedef struct _notifier_t
 } notifier_t;
 
 /**
- * Createion data structure used to encapsulate all inputs 
- * needed to create a notifier. 
+ * Createion data structure used to encapsulate all inputs
+ * needed to create a notifier.
  */
-typedef struct _notifier_create_params_t
-{
-  notifier_t *notifier;  /**< The data for the notifier must be provided by the client. This will be initialized by NotifierInit */
-  uint32_t notif_block_size; /**< This is the size of the data structure that represents a Notifier Block that is registered with a notification */
+typedef struct _notifier_create_params_t {
+  notifier_t *notifier; /**< The data for the notifier must be provided by the client. This will be
+                           initialized by NotifierInit */
+  uint32_t notif_block_size;  /**< This is the size of the data structure that represents a Notifier
+                                 Block that is registered with a notification */
   uint32_t max_registrations; /**< The maximum number of Notifications that can be registered.*/
-  uint32_t total_categories; /**< The total number of notification categories.*/
-  KListHead **notif_array; /**< The backing store to be used to save registered notifications */
+  uint32_t total_categories;  /**< The total number of notification categories.*/
+  KListHead **notif_array;    /**< The backing store to be used to save registered notifications */
   pool_create_params_t pool_params;
   notifier_f execute_f; /**< This is the Client specific notification callback.*/
   simple_logger_t log;
 } notifier_create_params_t;
 
-#define NOTIFIER_STORE_T( name )     _notifier_store_##name##_t
-#define NOTIFIER_STORE( name )       _notifier_store_##name
+#define NOTIFIER_STORE_T(name) _notifier_store_##name##_t
+#define NOTIFIER_STORE(name) _notifier_store_##name
 
-#define NOTIFIER_STORE_DECL( name, num_of_cat, max_regs, notif_reg_size)\
-POOL_STORE_DECL(notif_pool_##name, max_regs, notif_reg_size, 4);\
-typedef struct {\
-  KListHead* notifierArray[ num_of_cat ];\
-  notifier_t not;\
-}NOTIFIER_STORE_T( name );\
-size_t _notif_registration_size_##name = notif_reg_size;\
-uint32_t _notif_num_of_registrations_##name = max_regs
+#define NOTIFIER_STORE_DECL(name, num_of_cat, max_regs, notif_reg_size)                            \
+  POOL_STORE_DECL(notif_pool_##name, max_regs, notif_reg_size, 4);                                 \
+  typedef struct {                                                                                 \
+    KListHead *notifierArray[num_of_cat];                                                          \
+    notifier_t not;                                                                                \
+  } NOTIFIER_STORE_T(name);                                                                        \
+  size_t _notif_registration_size_##name = notif_reg_size;                                         \
+  uint32_t _notif_num_of_registrations_##name = max_regs
 
-#define NOTIFIER_STORE_DEF( name )\
-NOTIFIER_STORE_T( name ) NOTIFIER_STORE( name );\
-POOL_STORE_DEF(notif_pool_##name)
+#define NOTIFIER_STORE_DEF(name)                                                                   \
+  NOTIFIER_STORE_T(name) NOTIFIER_STORE(name);                                                     \
+  POOL_STORE_DEF(notif_pool_##name)
 
-
-// Use this macro to initialize a notifier_create_params_t if you created storage using the above DECL/DEF
-// macros.
-#define NOTIFIER_STORE_CREATE_PARAMS_INIT( params, name, notif_f, notif_name, should_log )\
-memset(&(params), 0, sizeof((params)));\
-(params).notifier = &NOTIFIER_STORE(name).not;\
-(params).notif_block_size = _notif_registration_size_##name;\
-(params).max_registrations = _notif_num_of_registrations_##name;\
-(params).total_categories = GetArraySize(NOTIFIER_STORE(name).notifierArray);\
-(params).notif_array = NOTIFIER_STORE(name).notifierArray;\
-memset(NOTIFIER_STORE(name).notifierArray, 0, sizeof(NOTIFIER_STORE(name).notifierArray));\
-POOL_CREATE_INIT((params).pool_params, notif_pool_##name);\
-(params).execute_f = notif_f;\
-(params).log = simple_logger_init(notif_name, should_log)
+// Use this macro to initialize a notifier_create_params_t if you created storage using the above
+// DECL/DEF macros.
+#define NOTIFIER_STORE_CREATE_PARAMS_INIT(params, name, notif_f, notif_name, should_log)           \
+  memset(&(params), 0, sizeof((params)));                                                          \
+  (params).notifier = &NOTIFIER_STORE(name).not;                                                   \
+  (params).notif_block_size = _notif_registration_size_##name;                                     \
+  (params).max_registrations = _notif_num_of_registrations_##name;                                 \
+  (params).total_categories = GetArraySize(NOTIFIER_STORE(name).notifierArray);                    \
+  (params).notif_array = NOTIFIER_STORE(name).notifierArray;                                       \
+  memset(NOTIFIER_STORE(name).notifierArray, 0, sizeof(NOTIFIER_STORE(name).notifierArray));       \
+  POOL_CREATE_INIT((params).pool_params, notif_pool_##name);                                       \
+  (params).execute_f = notif_f;                                                                    \
+  (params).log = simple_logger_init(notif_name, should_log)
 
 /**
- * NotifierInit - Creates a notifier based on the creation 
- * parameters supplied. 
- * 
- * \param pParams 
- * 
- * \return bool - true if successfully created. 
+ * NotifierInit - Creates a notifier based on the creation
+ * parameters supplied.
+ *
+ * \param pParams
+ *
+ * \return bool - true if successfully created.
  */
-bool notifier_init(notifier_create_params_t * params);
+bool notifier_init(notifier_create_params_t *params);
 
 /**
- * NotifierDeInit - DeInitializes a notifier. All registered 
- * notifications will be removed and resources cleaned up. 
- * 
- * \param pNotifier 
+ * NotifierDeInit - DeInitializes a notifier. All registered
+ * notifications will be removed and resources cleaned up.
+ *
+ * \param pNotifier
  */
-void notifier_deinit(notifier_t * notifier);
+void notifier_deinit(notifier_t *notifier);
 
 /**
- * NotifierAllocateNotificationBlock - Allocates a Notification 
- * block. The clients use this block to fill up the specific 
- * notification data and then registers with the notifier. 
- * 
- * \param pNotifier 
- * 
- * \return NotifierBlock* 
+ * NotifierAllocateNotificationBlock - Allocates a Notification
+ * block. The clients use this block to fill up the specific
+ * notification data and then registers with the notifier.
+ *
+ * \param pNotifier
+ *
+ * \return NotifierBlock*
  */
-notifier_block_t *notifier_allocate_notification_block(notifier_t * notifier);
+notifier_block_t *notifier_allocate_notification_block(notifier_t *notifier);
 
 /**
- * NotifierRegisterNotificationBlock - Used to register a 
- * specific notification. 
- * 
- * \param pNotif 
+ * NotifierRegisterNotificationBlock - Used to register a
+ * specific notification.
+ *
+ * \param pNotif
  * \param category - category for the notification.
- * \param pBlock 
- * 
- * \return bool 
+ * \param pBlock
+ *
+ * \return bool
  */
-bool notifier_register_notification_block(notifier_t * notifier, uint32_t category, notifier_block_t * block);
+bool notifier_register_notification_block(notifier_t *notifier,
+                                          uint32_t category,
+                                          notifier_block_t *block);
 
 /**
- * NotifierDeRegisterNotificationBlock - Removes a specific 
- * notification. 
- * 
- * \param pNotif 
- * \param pBlock 
+ * NotifierDeRegisterNotificationBlock - Removes a specific
+ * notification.
+ *
+ * \param pNotif
+ * \param pBlock
  */
-void notifier_deregister_notification_block(notifier_t * notifier, notifier_block_t * block);
+void notifier_deregister_notification_block(notifier_t *notifier, notifier_block_t *block);
 
 /**
- * NotifierPostNotification - Posts a notification and calls any 
- * callbacks that are registered for the specific notrification 
- * 
- * \param pNotif 
- * \param category 
- * \param pNotificationData 
+ * NotifierPostNotification - Posts a notification and calls any
+ * callbacks that are registered for the specific notrification
+ *
+ * \param pNotif
+ * \param category
+ * \param pNotificationData
  */
-void notifier_post_notification(notifier_t * notifier, uint32_t category, void *notification_data);
+void notifier_post_notification(notifier_t *notifier, uint32_t category, void *notification_data);

--- a/inc/cutils/os_types.h
+++ b/inc/cutils/os_types.h
@@ -21,8 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
- #pragma once
-
+#pragma once
 
 #ifdef __cplusplus
 #include <atomic>
@@ -38,14 +37,15 @@ extern "C" {
 #endif
 
 /**
- * @brief These macros are used in api's that block and have a parameter to specify the block duration.
+ * @brief These macros are used in api's that block and have a parameter to specify the block
+ * duration.
  */
-#define WAIT_FOREVER          ((uint32_t)-1)
-#define NO_SLEEP              (0)
+#define WAIT_FOREVER ((uint32_t)-1)
+#define NO_SLEEP (0)
 
 /**
- * @brief Prototype for callbacks used by dispatch apis. Allows to pass two context arguments whose durations should
- * be alive for the duration of the dispatch API being used.
+ * @brief Prototype for callbacks used by dispatch apis. Allows to pass two context arguments whose
+ * durations should be alive for the duration of the dispatch API being used.
  */
 typedef void (*dispatch_function_t)(void *arg1, void *arg2);
 

--- a/inc/cutils/pool.h
+++ b/inc/cutils/pool.h
@@ -24,38 +24,37 @@
 
 #pragma once
 
+#include <cutils/logger.h>
 #include <cutils/os_types.h>
 #include <cutils/ts_queue.h>
 #include <stdalign.h>
-#include <string.h>
 #include <stdatomic.h>
-#include <cutils/logger.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 /**
- * @brief This provides a static block pool implementation.  The pool allows the allocation of a fixed number of fixed
- * sized units specified at pool creation. Storage for the pool is provided using static storage and macros are provided
- * to create the storage needed for various pool instances
+ * @brief This provides a static block pool implementation.  The pool allows the allocation of a
+ * fixed number of fixed sized units specified at pool creation. Storage for the pool is provided
+ * using static storage and macros are provided to create the storage needed for various pool
+ * instances
  */
 
 /**
- * @brief Callback Signature for pool element destructor. Clients can install a destructor callback on individual
- * allocation out of a pool
+ * @brief Callback Signature for pool element destructor. Clients can install a destructor callback
+ * on individual allocation out of a pool
  */
-typedef void (*pool_element_destructor_f)(void *mem, void * private ) ;
+typedef void (*pool_element_destructor_f)(void *mem, void *private);
 
-typedef struct
-{
+typedef struct {
   ts_queue_t *q;
   size_t num_of_elements;
   size_t element_size;
   size_t offset_data_from_header;
 } pool_t;
 
-typedef struct _pool_header_t
-{
+typedef struct _pool_header_t {
   uint32_t sanity;
   atomic_uint retain_count;
   pool_element_destructor_f destructor;
@@ -63,39 +62,37 @@ typedef struct _pool_header_t
 } pool_header_t;
 
 #define POOL_STORE_TYPE(name) pool_static_backing_store_##name##_t
-#define POOL_STORE_PTR_TYPE(name) POOL_STORE_TYPE( name )*
+#define POOL_STORE_PTR_TYPE(name) POOL_STORE_TYPE(name) *
 #define POOL_STORE(name) _pool_backing_store_##name
 
 /**
- * @brief Storage for a pool is created statically. This is the first part of creating the storage needed to be used by a pool
- * Use this macro to create  a declaration for the specific pool storage that the client wishes to create.
- * For instance, if a client wants to create a pool with each element being the size of a ULONG and a total of 8 ULONGs
- * all aligned to 16 bytes, Storage will be declared using this macro.
- * ie POOL_STORE_DECL(someMacroIdentifier, 8, sizeof(ULONG), 16)
+ * @brief Storage for a pool is created statically. This is the first part of creating the storage
+ * needed to be used by a pool Use this macro to create  a declaration for the specific pool storage
+ * that the client wishes to create. For instance, if a client wants to create a pool with each
+ * element being the size of a ULONG and a total of 8 ULONGs all aligned to 16 bytes, Storage will
+ * be declared using this macro. ie POOL_STORE_DECL(someMacroIdentifier, 8, sizeof(ULONG), 16)
  */
-#define POOL_STORE_DECL(name, num_elemens, element_size, align)\
-TS_QUEUE_STORE_DECL(pool_##name, num_elemens);\
-typedef struct\
-{\
-  struct {\
-     pool_header_t header;\
-     alignas(align) uint8_t data[ element_size ];\
-     uint32_t trailer_sanity;\
-  }elements[num_elemens];\
-  pool_t pool;\
-}POOL_STORE_TYPE( name )
+#define POOL_STORE_DECL(name, num_elemens, element_size, align)                                    \
+  TS_QUEUE_STORE_DECL(pool_##name, num_elemens);                                                   \
+  typedef struct {                                                                                 \
+    struct {                                                                                       \
+      pool_header_t header;                                                                        \
+      alignas(align) uint8_t data[element_size];                                                   \
+      uint32_t trailer_sanity;                                                                     \
+    } elements[num_elemens];                                                                       \
+    pool_t pool;                                                                                   \
+  } POOL_STORE_TYPE(name)
 
 /**
- * @brief Storage for a pool is created statically. This is the second part of creating the storage needed by a pool.
- * Use this macro after declaring a pool storage as above. Continuing with the above example,
- * POOL_STORE_DEF(someMacroIdentifier)
+ * @brief Storage for a pool is created statically. This is the second part of creating the storage
+ * needed by a pool. Use this macro after declaring a pool storage as above. Continuing with the
+ * above example, POOL_STORE_DEF(someMacroIdentifier)
  */
-#define POOL_STORE_DEF(name)\
-POOL_STORE_TYPE( name ) POOL_STORE( name );\
-TS_QUEUE_STORE_DEF(pool_##name)
+#define POOL_STORE_DEF(name)                                                                       \
+  POOL_STORE_TYPE(name) POOL_STORE(name);                                                          \
+  TS_QUEUE_STORE_DEF(pool_##name)
 
-typedef struct _pool_create_params_t
-{
+typedef struct _pool_create_params_t {
   pool_t *p_pool;
   uint32_t num_of_elements;
   uint32_t element_size_requested;
@@ -106,53 +103,58 @@ typedef struct _pool_create_params_t
 } pool_create_params_t;
 
 /**
- * @brief This is the final part for creating a pool from static storage. Use this macro to create a pool_create_params_t
- * data structure used by pool_new() using the storage created using POOL_STORE_DEF(). Continuing with the example
+ * @brief This is the final part for creating a pool from static storage. Use this macro to create a
+ * pool_create_params_t data structure used by pool_new() using the storage created using
+ * POOL_STORE_DEF(). Continuing with the example
  * {
  *   pool_create_params_t create_params;
  *   POOL_CREATE_INIT(params, someMacroIdentifier);
  *   pool_t *p_pool = pool_new(&create_params);
  * }
  */
-#define POOL_CREATE_INIT(params, name)\
-memset(&(params), 0, sizeof((params)));\
-(params).p_pool = &POOL_STORE(name).pool;\
-(params).num_of_elements = GetArraySize(POOL_STORE(name).elements);\
-(params).element_size_requested = sizeof(POOL_STORE(name).elements[0].data);\
-(params).total_element_size = sizeof(POOL_STORE(name).elements[0]);\
-(params).p_backing = (uint8_t*)POOL_STORE(name).elements;\
-(params).offset_data_from_header = (size_t)POOL_STORE(name).elements[0].data - (size_t)&POOL_STORE(name).elements[0].header;\
-TS_QUEUE_STORE_CREATE_PARAMS_INIT((params).queue_params, pool_##name)
+#define POOL_CREATE_INIT(params, name)                                                             \
+  memset(&(params), 0, sizeof((params)));                                                          \
+  (params).p_pool = &POOL_STORE(name).pool;                                                        \
+  (params).num_of_elements = GetArraySize(POOL_STORE(name).elements);                              \
+  (params).element_size_requested = sizeof(POOL_STORE(name).elements[0].data);                     \
+  (params).total_element_size = sizeof(POOL_STORE(name).elements[0]);                              \
+  (params).p_backing = (uint8_t *)POOL_STORE(name).elements;                                       \
+  (params).offset_data_from_header =                                                               \
+      (size_t)POOL_STORE(name).elements[0].data - (size_t)&POOL_STORE(name).elements[0].header;    \
+  TS_QUEUE_STORE_CREATE_PARAMS_INIT((params).queue_params, pool_##name)
 
-#define POOL_ELEMENT_HEADER_SANITY      (0xDEADBEEF)
-#define POOL_ELEMENT_TRAILER_SANITY     (0xFACEB007)
+#define POOL_ELEMENT_HEADER_SANITY (0xDEADBEEF)
+#define POOL_ELEMENT_TRAILER_SANITY (0xFACEB007)
 
 /**
- * @brief Creates a new pool specified by the `create_params` specified. Use the static storage macros above
- * to create the create_params.
- * @param create_params - parameters specifying the attributes of the pool. Static storage must already be provided
+ * @brief Creates a new pool specified by the `create_params` specified. Use the static storage
+ * macros above to create the create_params.
+ * @param create_params - parameters specifying the attributes of the pool. Static storage must
+ * already be provided
  * @return - pointer to the created pool if successful, NULL otherwise
  */
-static inline pool_t *pool_create(pool_create_params_t *create_params)
-{
+static inline pool_t *pool_create(pool_create_params_t *create_params) {
   pool_t *retval = 0;
   if (create_params->p_pool) {
     memset(create_params->p_pool, 0, sizeof(pool_t));
     create_params->p_pool->q = ts_queue_init(&create_params->queue_params);
-    CHECK_RUN(create_params->p_pool->q, return retval, "%s(): Couldn't create static queue", __FUNCTION__);
+    CHECK_RUN(create_params->p_pool->q,
+              return retval,
+              "%s(): Couldn't create static queue",
+              __FUNCTION__);
     if (create_params->p_pool->q) {
       create_params->p_pool->num_of_elements = create_params->num_of_elements;
       create_params->p_pool->element_size = create_params->element_size_requested;
       create_params->p_pool->offset_data_from_header = create_params->offset_data_from_header;
       for (uint32_t i = 0; i < create_params->num_of_elements; i++) {
-        uint8_t *data =
-            create_params->p_backing + (i * create_params->total_element_size) + create_params->offset_data_from_header;
-        pool_header_t *p_header = (pool_header_t*)(data - create_params->offset_data_from_header);
+        uint8_t *data = create_params->p_backing + (i * create_params->total_element_size) +
+                        create_params->offset_data_from_header;
+        pool_header_t *p_header = (pool_header_t *)(data - create_params->offset_data_from_header);
         uint32_t *p_trailer_sanity;
         memset(p_header, 0, sizeof(pool_header_t));
         p_header->sanity = POOL_ELEMENT_HEADER_SANITY;
         atomic_init(&p_header->retain_count, 0);
-        p_trailer_sanity = (uint32_t*)((size_t)data + create_params->element_size_requested);
+        p_trailer_sanity = (uint32_t *)((size_t)data + create_params->element_size_requested);
         *p_trailer_sanity = POOL_ELEMENT_TRAILER_SANITY;
         ts_queue_enqueue(create_params->p_pool->q, data, NO_SLEEP);
       }
@@ -162,11 +164,11 @@ static inline pool_t *pool_create(pool_create_params_t *create_params)
   return retval;
 }
 /**
- * @brief Will release the resources in a pool. Clients should not use the pool after freeing with this
+ * @brief Will release the resources in a pool. Clients should not use the pool after freeing with
+ * this
  * @param p_pool - A valid allocated pool
  */
-static inline void pool_destroy(pool_t *p_pool)
-{
+static inline void pool_destroy(pool_t *p_pool) {
   if (p_pool) {
     ts_queue_destroy(p_pool->q);
     p_pool->q = 0;
@@ -174,23 +176,25 @@ static inline void pool_destroy(pool_t *p_pool)
 }
 
 /**
- * @brief Will allocate a fixed size block from the pool. Will block for `wait_ms` if the pool is empty.
+ * @brief Will allocate a fixed size block from the pool. Will block for `wait_ms` if the pool is
+ * empty.
  * @param p_pool - Created and valid pool
  * @param wait_ms - number of ticks to sleep if queue empty.
  * @param fnDestroy - An optional destructor  to be used with the allocation
  * @param destructor_private - Private Client data to be suplplied with the destructor
  * @return - a block allocated from the pool if successful, NULL otherwise
  */
-static inline void *
-pool_alloc_blocking(pool_t *p_pool, uint32_t wait_ms, pool_element_destructor_f fnDestroy, void *destructor_private)
-{
+static inline void *pool_alloc_blocking(pool_t *p_pool,
+                                        uint32_t wait_ms,
+                                        pool_element_destructor_f fnDestroy,
+                                        void *destructor_private) {
   void *retval = 0;
   if (p_pool) {
     pool_header_t *p_header = 0;
     if (ts_queue_dequeue(p_pool->q, &retval, wait_ms)) {
-      p_header = (pool_header_t*)((uint8_t*)retval - p_pool->offset_data_from_header);
+      p_header = (pool_header_t *)((uint8_t *)retval - p_pool->offset_data_from_header);
       CUTILS_ASSERT(p_header->sanity == POOL_ELEMENT_HEADER_SANITY);
-      CUTILS_ASSERT(*((uint32_t *) (retval + p_pool->element_size)) == POOL_ELEMENT_TRAILER_SANITY);
+      CUTILS_ASSERT(*((uint32_t *)(retval + p_pool->element_size)) == POOL_ELEMENT_TRAILER_SANITY);
       atomic_fetch_add_explicit(&p_header->retain_count, 1, memory_order_relaxed);
       if (fnDestroy) {
         p_header->destructor = fnDestroy;
@@ -206,42 +210,42 @@ pool_alloc_blocking(pool_t *p_pool, uint32_t wait_ms, pool_element_destructor_f 
  * @param p_pool - A Valid Pool
  * @return - a block allocated from the pool if successful, NULL otherwise
  */
-static inline void *pool_alloc(pool_t *p_pool)
-{ return pool_alloc_blocking(p_pool, NO_SLEEP, NULL, NULL); }
+static inline void *pool_alloc(pool_t *p_pool) {
+  return pool_alloc_blocking(p_pool, NO_SLEEP, NULL, NULL);
+}
 
 /**
  * @brief Increases the reference count of an allocation from the specified pool
  * @param p_pool - a Valid Pool
  * @param p_mem - A previously allocated block from the supplied pool
  */
-static inline void pool_retain(pool_t *p_pool, void *p_mem)
-{
+static inline void pool_retain(pool_t *p_pool, void *p_mem) {
   if (p_pool) {
     pool_header_t *p_header = p_mem - p_pool->offset_data_from_header;
     CUTILS_ASSERT(p_header->sanity == POOL_ELEMENT_HEADER_SANITY);
-    CUTILS_ASSERT(*((uint32_t *) (p_mem + p_pool->element_size)) == POOL_ELEMENT_TRAILER_SANITY);
+    CUTILS_ASSERT(*((uint32_t *)(p_mem + p_pool->element_size)) == POOL_ELEMENT_TRAILER_SANITY);
     atomic_fetch_add_explicit(&p_header->retain_count, 1, memory_order_relaxed);
   }
 }
 
 /**
- * @brief - Returns the supplied block back to the pool if the reference count hits zero. Otherwise simply
- * lowers the reference count of the supplied allocation. Clients should not use the supplied memory block after
- * calling this function on the block.
+ * @brief - Returns the supplied block back to the pool if the reference count hits zero. Otherwise
+ * simply lowers the reference count of the supplied allocation. Clients should not use the supplied
+ * memory block after calling this function on the block.
  * @param p_pool - a valid pool
  * @param p_mem - Block Allocation to return to the pool
  */
-static inline void pool_free(pool_t *p_pool, void *p_mem)
-{
+static inline void pool_free(pool_t *p_pool, void *p_mem) {
   if (p_pool) {
     pool_header_t *p_header = p_mem - p_pool->offset_data_from_header;
     uint32_t old_retain_count;
     CUTILS_ASSERT(p_header->sanity == POOL_ELEMENT_HEADER_SANITY);
-    CUTILS_ASSERT(*((uint32_t *) (p_mem + p_pool->element_size)) == POOL_ELEMENT_TRAILER_SANITY);
+    CUTILS_ASSERT(*((uint32_t *)(p_mem + p_pool->element_size)) == POOL_ELEMENT_TRAILER_SANITY);
     old_retain_count = atomic_fetch_sub_explicit(&p_header->retain_count, 1, memory_order_acq_rel);
     CUTILS_ASSERT(old_retain_count != 0);
     if (old_retain_count == 1) {
-      if (p_header->destructor) p_header->destructor(p_mem, p_header->destructor_private);
+      if (p_header->destructor)
+        p_header->destructor(p_mem, p_header->destructor_private);
       ts_queue_enqueue(p_pool->q, p_mem, NO_SLEEP);
     }
   }
@@ -254,13 +258,14 @@ static inline void pool_free(pool_t *p_pool, void *p_mem)
  * @param fnDestroy - A destructor to be called when the allocation is released to the pool
  * @param destructor_private - Client data to be supplied to the destructor callback.
  */
-static inline void
-pool_set_destructor(pool_t *p_pool, void *p_mem, pool_element_destructor_f fnDestroy, void *destructor_private)
-{
+static inline void pool_set_destructor(pool_t *p_pool,
+                                       void *p_mem,
+                                       pool_element_destructor_f fnDestroy,
+                                       void *destructor_private) {
   if (p_pool && p_mem) {
     pool_header_t *p_header = p_mem - p_pool->offset_data_from_header;
     CUTILS_ASSERT(p_header->sanity == POOL_ELEMENT_HEADER_SANITY);
-    CUTILS_ASSERT(*((uint32_t *) (p_mem + p_pool->element_size)) == POOL_ELEMENT_TRAILER_SANITY);
+    CUTILS_ASSERT(*((uint32_t *)(p_mem + p_pool->element_size)) == POOL_ELEMENT_TRAILER_SANITY);
     p_header->destructor = fnDestroy;
     p_header->destructor_private = destructor_private;
   }

--- a/inc/cutils/pthread/event_flag.h
+++ b/inc/cutils/pthread/event_flag.h
@@ -9,10 +9,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,16 +31,14 @@
 extern "C" {
 #endif
 
-typedef enum _event_flag_wait_type_e
-{
+typedef enum _event_flag_wait_type_e {
   WAIT_OR,
   WAIT_OR_CLEAR,
   WAIT_AND,
   WAIT_AND_CLEAR
 } event_flag_wait_type_e;
 
-typedef struct _event_flag_t
-{
+typedef struct _event_flag_t {
   pthread_cond_t cv;
   pthread_mutex_t mtx;
   uint32_t val;
@@ -50,8 +48,11 @@ bool event_flag_new(event_flag_t *p_flags);
 
 bool event_flag_free(event_flag_t *p_flags);
 
-bool event_flag_wait(event_flag_t *p_flags, uint32_t required_flags, event_flag_wait_type_e wait_type,
-                     uint32_t *p_actual_flags, uint32_t wait_ms);
+bool event_flag_wait(event_flag_t *p_flags,
+                     uint32_t required_flags,
+                     event_flag_wait_type_e wait_type,
+                     uint32_t *p_actual_flags,
+                     uint32_t wait_ms);
 
 bool event_flag_send(event_flag_t *p_flags, uint32_t flag_bits);
 

--- a/inc/cutils/pthread/mutex.h
+++ b/inc/cutils/pthread/mutex.h
@@ -9,10 +9,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,13 +31,11 @@
 extern "C" {
 #endif
 
-typedef struct _mutex_t
-{
+typedef struct _mutex_t {
   pthread_mutex_t mtx;
 } mutex_t;
 
-static inline bool mutex_new(mutex_t *mutex)
-{
+static inline bool mutex_new(mutex_t *mutex) {
   bool res = false;
   pthread_mutexattr_t attr;
 
@@ -45,7 +43,7 @@ static inline bool mutex_new(mutex_t *mutex)
 
   pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_TIMED_NP);
 
-  if(0) {
+  if (0) {
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
   }
 
@@ -54,32 +52,29 @@ static inline bool mutex_new(mutex_t *mutex)
   return res;
 }
 
-static inline void mutex_free(mutex_t *mutex)
-{
+static inline void mutex_free(mutex_t *mutex) {
   if (mutex) {
     pthread_mutex_destroy(&mutex->mtx);
   }
 }
 
-static inline bool mutex_lock(mutex_t *mutex, uint32_t wait_ms)
-{
+static inline bool mutex_lock(mutex_t *mutex, uint32_t wait_ms) {
   bool retval = false;
   if (mutex) {
-    if(!wait_ms) {
+    if (!wait_ms) {
       retval = !pthread_mutex_trylock(&mutex->mtx);
     } else {
       struct timespec tm = {0};
       clock_gettime(CLOCK_REALTIME, &tm);
-      tm.tv_sec += wait_ms/1000;
-      tm.tv_nsec += 1000000 * ( wait_ms % 1000);
+      tm.tv_sec += wait_ms / 1000;
+      tm.tv_nsec += 1000000 * (wait_ms % 1000);
       retval = (!pthread_mutex_timedlock(&mutex->mtx, &tm));
     }
   }
   return retval;
 }
 
-static inline bool mutex_unlock(mutex_t *mutex)
-{
+static inline bool mutex_unlock(mutex_t *mutex) {
   bool retval = false;
   if (mutex) {
     retval = (!pthread_mutex_unlock(&mutex->mtx));

--- a/inc/cutils/pthread/task.h
+++ b/inc/cutils/pthread/task.h
@@ -9,10 +9,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,24 +27,26 @@
 #include <cutils/os_types.h>
 #include <pthread.h>
 
-#define SCHEDULING_POLICY               (SCHED_OTHER)
+#define SCHEDULING_POLICY (SCHED_OTHER)
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define CUTILS_TASK_PRIORITY_LOWEST     (sched_get_priority_min(SCHEDULING_POLICY))
-#define CUTILS_TASK_PRIORITY_HIGHEST    (sched_get_priority_max(SCHEDULING_POLICY))
-#define CUTILS_TASK_PRIORITY_MEDIUM     (( CUTILS_TASK_PRIORITY_LOWEST + CUTILS_TASK_PRIORITY_HIGHEST ) / 2)
-#define CUTILS_TASK_PRIORITY_MID_HIGH   (CUTILS_TASK_PRIORITY_MEDIUM - ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST)/4))
-#define CUTILS_TASK_PRIORITY_MID_LO     (CUTILS_TASK_PRIORITY_MEDIUM + ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST)/4))
+#define CUTILS_TASK_PRIORITY_LOWEST (sched_get_priority_min(SCHEDULING_POLICY))
+#define CUTILS_TASK_PRIORITY_HIGHEST (sched_get_priority_max(SCHEDULING_POLICY))
+#define CUTILS_TASK_PRIORITY_MEDIUM                                                                \
+  ((CUTILS_TASK_PRIORITY_LOWEST + CUTILS_TASK_PRIORITY_HIGHEST) / 2)
+#define CUTILS_TASK_PRIORITY_MID_HIGH                                                              \
+  (CUTILS_TASK_PRIORITY_MEDIUM - ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST) / 4))
+#define CUTILS_TASK_PRIORITY_MID_LO                                                                \
+  (CUTILS_TASK_PRIORITY_MEDIUM + ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST) / 4))
 
-#define CUTILS_TASK_STACK_MIN_SIZE               (PTHREAD_STACK_MIN)
+#define CUTILS_TASK_STACK_MIN_SIZE (PTHREAD_STACK_MIN)
 #define DEFAULT_TASK_PRIORITY CUTILS_TASK_PRIORITY_MEDIUM
 
-typedef void (*task_func_t)(void*);
+typedef void (*task_func_t)(void *);
 
-typedef struct _task_t
-{
+typedef struct _task_t {
   pthread_t task;
   uint32_t sanity;
   char label[30];
@@ -52,8 +54,7 @@ typedef struct _task_t
   void *ctx;
 } task_t;
 
-typedef struct _task_create_params_t
-{
+typedef struct _task_create_params_t {
   task_t *task;
   char *label;
   uint32_t priority;
@@ -68,23 +69,23 @@ typedef struct _task_create_params_t
 #define TASK_STATIC_STORE(name) _task_store_##name
 
 // Stack alignment at 4K for 32-bit code and 1M for 64-bit
-#define TASK_STATIC_STORE_DECL(name, stack_size)\
-typedef struct {\
-  alignas(1<<((sizeof(void*) == 4)?12 : 20)) uint8_t stack[ (stack_size) ];\
-  task_t tsk;\
-}TASK_STATIC_STORE_T( name )
+#define TASK_STATIC_STORE_DECL(name, stack_size)                                                   \
+  typedef struct {                                                                                 \
+    alignas(1 << ((sizeof(void *) == 4) ? 12 : 20)) uint8_t stack[(stack_size)];                   \
+    task_t tsk;                                                                                    \
+  } TASK_STATIC_STORE_T(name)
 
-#define TASK_STATIC_STORE_DEF(name)\
-TASK_STATIC_STORE_T( name ) TASK_STATIC_STORE(name) __attribute__((section(".bss.noinit"),used))
+#define TASK_STATIC_STORE_DEF(name)                                                                \
+  TASK_STATIC_STORE_T(name) TASK_STATIC_STORE(name) __attribute__((section(".bss.noinit"), used))
 
-#define TASK_STATIC_INIT_CREATE_PARAMS(params, name, lbl, pri, fn, context)\
-  memset(&(params), 0, sizeof((params)));\
-  (params).task = &TASK_STATIC_STORE(name).tsk;\
-  (params).label = (char*)(lbl);\
-  (params).priority = pri;\
-  (params).func = fn;\
-  (params).ctx = context;\
-  (params).stack = TASK_STATIC_STORE(name).stack;\
+#define TASK_STATIC_INIT_CREATE_PARAMS(params, name, lbl, pri, fn, context)                        \
+  memset(&(params), 0, sizeof((params)));                                                          \
+  (params).task = &TASK_STATIC_STORE(name).tsk;                                                    \
+  (params).label = (char *)(lbl);                                                                  \
+  (params).priority = pri;                                                                         \
+  (params).func = fn;                                                                              \
+  (params).ctx = context;                                                                          \
+  (params).stack = TASK_STATIC_STORE(name).stack;                                                  \
   (params).stack_size = sizeof(TASK_STATIC_STORE(name).stack)
 
 task_t *task_new_static(task_create_params_t *create_params);

--- a/inc/cutils/pthread/ts_queue.h
+++ b/inc/cutils/pthread/ts_queue.h
@@ -9,10 +9,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,8 +24,8 @@
 
 #pragma once
 
-#include <cutils/mutex.h>
 #include <cutils/logger.h>
+#include <cutils/mutex.h>
 #include <errno.h>
 
 #ifdef __cplusplus
@@ -36,51 +36,50 @@ typedef struct {
   pthread_cond_t cnd;
   pthread_cond_t full_cnd;
   mutex_t mtx;
-  void** pp_ptr_array;
+  void **pp_ptr_array;
   size_t size;
   size_t count;
   atomic_ulong head;
   atomic_ulong tail;
-}ts_queue_t;
+} ts_queue_t;
 
-#define TS_QUEUE_STORE(name)      _ts_queue_store_##name
-#define TS_QUEUE_STORE_T(name)    _ts_queue_store_##name##_t
-#define TS_QUEUE_STORE_DECL(name, size) \
-static size_t _ts_queue_store_num_elements_##name = size;\
-typedef struct {\
-  void* ptr_array[size];\
-  ts_queue_t queue;\
-}TS_QUEUE_STORE_T(name)
+#define TS_QUEUE_STORE(name) _ts_queue_store_##name
+#define TS_QUEUE_STORE_T(name) _ts_queue_store_##name##_t
+#define TS_QUEUE_STORE_DECL(name, size)                                                            \
+  static size_t _ts_queue_store_num_elements_##name = size;                                        \
+  typedef struct {                                                                                 \
+    void *ptr_array[size];                                                                         \
+    ts_queue_t queue;                                                                              \
+  } TS_QUEUE_STORE_T(name)
 
-#define TS_QUEUE_STORE_DEF(name) \
-static TS_QUEUE_STORE_T(name) TS_QUEUE_STORE(name)
+#define TS_QUEUE_STORE_DEF(name) static TS_QUEUE_STORE_T(name) TS_QUEUE_STORE(name)
 
 typedef struct {
-  ts_queue_t* p_queue;
+  ts_queue_t *p_queue;
   void **ptr_array;
   size_t size;
-}ts_queue_create_params_t;
+} ts_queue_create_params_t;
 
-#define TS_QUEUE_STORE_CREATE_PARAMS_INIT(params, name) \
-memset(&(params), 0, sizeof((params)));\
-(params).p_queue = &TS_QUEUE_STORE(name).queue;\
-(params).ptr_array = TS_QUEUE_STORE(name).ptr_array;\
-(params).size = _ts_queue_store_num_elements_##name
+#define TS_QUEUE_STORE_CREATE_PARAMS_INIT(params, name)                                            \
+  memset(&(params), 0, sizeof((params)));                                                          \
+  (params).p_queue = &TS_QUEUE_STORE(name).queue;                                                  \
+  (params).ptr_array = TS_QUEUE_STORE(name).ptr_array;                                             \
+  (params).size = _ts_queue_store_num_elements_##name
 
-static inline ts_queue_t *ts_queue_init(ts_queue_create_params_t *params)
-{
+static inline ts_queue_t *ts_queue_init(ts_queue_create_params_t *params) {
   ts_queue_t *retval = 0;
-  if(params && params->p_queue && params->ptr_array) {
+  if (params && params->p_queue && params->ptr_array) {
     params->p_queue->pp_ptr_array = params->ptr_array;
     params->p_queue->size = params->size;
-    CHECK_RUN(params->p_queue->size > 0 && (params->p_queue->size & (params->p_queue->size -1)) == 0,
-        return retval, "Queue Size must be a power of 2");
+    CHECK_RUN(params->p_queue->size > 0 &&
+                  (params->p_queue->size & (params->p_queue->size - 1)) == 0,
+              return retval,
+              "Queue Size must be a power of 2");
     CHECK_RUN(mutex_new(&params->p_queue->mtx), return retval, "Failed to create Mutex");
     CHECK_RUN(!pthread_cond_init(&params->p_queue->cnd, 0) &&
-              !pthread_cond_init(&params->p_queue->full_cnd, 0),
+                  !pthread_cond_init(&params->p_queue->full_cnd, 0),
               mutex_free(&params->p_queue->mtx);
-              return retval,
-              "Failed to create Condition variable");
+              return retval, "Failed to create Condition variable");
     params->p_queue->count = 0;
     params->p_queue->head = params->p_queue->tail = 0;
     retval = params->p_queue;
@@ -88,35 +87,33 @@ static inline ts_queue_t *ts_queue_init(ts_queue_create_params_t *params)
   return retval;
 }
 
-static inline void ts_queue_destroy(ts_queue_t *p_queue)
-{
-  if(p_queue) {
+static inline void ts_queue_destroy(ts_queue_t *p_queue) {
+  if (p_queue) {
     pthread_cond_destroy(&p_queue->cnd);
     mutex_free(&p_queue->mtx);
   }
 }
 
-static inline bool ts_queue_enqueue(ts_queue_t* p_queue, void* p_item, uint32_t wait_ms)
-{
+static inline bool ts_queue_enqueue(ts_queue_t *p_queue, void *p_item, uint32_t wait_ms) {
   struct timespec ts = {0};
   bool retval = false;
 
   clock_gettime(CLOCK_REALTIME, &ts);
-  if(wait_ms != WAIT_FOREVER) {
-    ts.tv_sec += wait_ms/1000;
+  if (wait_ms != WAIT_FOREVER) {
+    ts.tv_sec += wait_ms / 1000;
     ts.tv_nsec += ((long)wait_ms % 1000) * 1000000;
   }
-  if(p_queue && p_item) {
+  if (p_queue && p_item) {
     mutex_lock(&p_queue->mtx, WAIT_FOREVER);
     int rval = 0;
-    while(p_queue->tail + p_queue->size <= p_queue->head && rval != ETIMEDOUT) {
-      if(wait_ms == WAIT_FOREVER) {
+    while (p_queue->tail + p_queue->size <= p_queue->head && rval != ETIMEDOUT) {
+      if (wait_ms == WAIT_FOREVER) {
         rval = pthread_cond_wait(&p_queue->full_cnd, &p_queue->mtx.mtx);
       } else {
         rval = pthread_cond_timedwait(&p_queue->full_cnd, &p_queue->mtx.mtx, &ts);
       }
     }
-    if(rval != ETIMEDOUT) {
+    if (rval != ETIMEDOUT) {
       p_queue->pp_ptr_array[atomic_fetch_add(&p_queue->head, 1UL) & (p_queue->size - 1)] = p_item;
       p_queue->count++;
       pthread_cond_signal(&p_queue->cnd);
@@ -128,30 +125,29 @@ static inline bool ts_queue_enqueue(ts_queue_t* p_queue, void* p_item, uint32_t 
   return retval;
 }
 
-static inline bool ts_queue_dequeue(ts_queue_t* p_queue, void** pp_item, uint32_t wait_ms)
-{
+static inline bool ts_queue_dequeue(ts_queue_t *p_queue, void **pp_item, uint32_t wait_ms) {
   bool retval = false;
   struct timespec ts = {0};
   clock_gettime(CLOCK_REALTIME, &ts);
 
-  if(wait_ms != WAIT_FOREVER) {
-    ts.tv_sec += wait_ms/1000;
+  if (wait_ms != WAIT_FOREVER) {
+    ts.tv_sec += wait_ms / 1000;
     ts.tv_nsec += ((long)wait_ms % 1000) * 1000000;
   }
-  if(p_queue && pp_item) {
+  if (p_queue && pp_item) {
     int rval = 0;
-    //This is always blocking because the mutex is only taken for non-blocking operations.
-    //Only the condition variable wait is timed, since there is no bound on how long it will
-    //take for an item to be enqueued onto the queue.
+    // This is always blocking because the mutex is only taken for non-blocking operations.
+    // Only the condition variable wait is timed, since there is no bound on how long it will
+    // take for an item to be enqueued onto the queue.
     mutex_lock(&p_queue->mtx, WAIT_FOREVER);
-    while(p_queue->tail >= p_queue->head && rval != ETIMEDOUT) {
-      if(wait_ms == WAIT_FOREVER) {
+    while (p_queue->tail >= p_queue->head && rval != ETIMEDOUT) {
+      if (wait_ms == WAIT_FOREVER) {
         rval = pthread_cond_wait(&p_queue->cnd, &p_queue->mtx.mtx);
       } else {
         rval = pthread_cond_timedwait(&p_queue->cnd, &p_queue->mtx.mtx, &ts);
       }
     }
-    if(rval == 0) {
+    if (rval == 0) {
       *pp_item = p_queue->pp_ptr_array[atomic_fetch_add(&p_queue->tail, 1UL) & (p_queue->size - 1)];
       p_queue->count--;
       pthread_cond_signal(&p_queue->full_cnd);
@@ -162,12 +158,8 @@ static inline bool ts_queue_dequeue(ts_queue_t* p_queue, void** pp_item, uint32_
   return retval;
 }
 
-static inline size_t ts_queue_get_count(ts_queue_t* p_queue)
-{
-  return p_queue->count;
-}
+static inline size_t ts_queue_get_count(ts_queue_t *p_queue) { return p_queue->count; }
 
 #ifdef __cplusplus
 };
 #endif
-

--- a/inc/cutils/ring_buffer.h
+++ b/inc/cutils/ring_buffer.h
@@ -38,31 +38,26 @@ extern "C" {
 #include <stdio.h>
 #include <string.h>
 
-
 /**
  Holds the location / size of a chunk of data in the buffer.
  */
-typedef struct
-{
+typedef struct {
   uint32_t location;
   uint32_t length;
 } data_range_t;
 
-static inline data_range_t make_data_range(uint32_t loc, uint32_t len)
-{
+static inline data_range_t make_data_range(uint32_t loc, uint32_t len) {
   data_range_t r;
   r.location = loc;
   r.length = len;
   return r;
 }
 
-static inline bool location_in_data_range(uint32_t loc, data_range_t range)
-{
+static inline bool location_in_data_range(uint32_t loc, data_range_t range) {
   return (!(loc < range.location) && (loc - range.location) < range.length) ? true : false;
 }
 
-static inline uint32_t max_data_range(data_range_t range)
-{
+static inline uint32_t max_data_range(data_range_t range) {
   return (range.location + range.length);
 }
 
@@ -70,36 +65,35 @@ static inline uint32_t max_data_range(data_range_t range)
  Points to a chunk of data in the buffer.
  NOTE:
  The memory location pointed by data is owned by the buffer and NOT copied.
- You should copy this data if you plan to use it later, as the buffer may overwrite this location with new data.
+ You should copy this data if you plan to use it later, as the buffer may overwrite this location
+ with new data.
  */
-typedef struct
-{
+typedef struct {
   uint8_t *data;
   uint32_t length;
 } buffer_data_t;
 
-
 /**
- For data reads, if the data wraps around, it will contain 2 sections of data, since the bytes are NOT copied.
- entryCount contains the amount of data regions set.
- totalBytes is the total aggregated amount of data of all data regions.
+ For data reads, if the data wraps around, it will contain 2 sections of data, since the bytes are
+ NOT copied. entryCount contains the amount of data regions set. totalBytes is the total aggregated
+ amount of data of all data regions.
  */
-typedef struct
-{
+typedef struct {
   int entryCount;
   uint32_t total_bytes;
   buffer_data_t data[2];
 } ring_buffer_data_t;
 
-static inline void copy_ring_data_to_buffer(ring_buffer_data_t *data_to_copy, uint8_t *dst)
-{
+static inline void copy_ring_data_to_buffer(ring_buffer_data_t *data_to_copy, uint8_t *dst) {
   if (data_to_copy->entryCount == 0) {
     return;
   }
 
   memcpy(dst, data_to_copy->data[0].data, data_to_copy->data[0].length);
   if (data_to_copy->entryCount == 2) {
-    memcpy(dst + data_to_copy->data[0].length, data_to_copy->data[1].data, data_to_copy->data[1].length);
+    memcpy(dst + data_to_copy->data[0].length,
+           data_to_copy->data[1].data,
+           data_to_copy->data[1].length);
   }
 }
 
@@ -113,18 +107,18 @@ typedef struct ring_buffer *ring_buffer_ref;
  */
 typedef void (*data_changed_at_range_f)(ring_buffer_ref buffer, void *ctx, data_range_t range);
 
-typedef struct ring_buffer
-{
+typedef struct ring_buffer {
   uint32_t size;
 
   /*
-   Sequentially consistent is the default type for classic C-style operations on _Atomic() variables.
-   _Atomic(int) a = 42;
+   Sequentially consistent is the default type for classic C-style operations on _Atomic()
+   variables. _Atomic(int) a = 42;
    ...
    a++; // <- This is sequentially consistent
    http://www.informit.com/articles/article.aspx?p=1832575&seqNum=4
    */
-  atomic_ullong read_offset;   // start offset for available data. these monotonically increase and do not wrap around
+  atomic_ullong read_offset; // start offset for available data. these monotonically increase and do
+                             // not wrap around
   atomic_ullong write_offset;
 
   // ptr to the mapped region
@@ -134,31 +128,30 @@ typedef struct ring_buffer
   void *ctx;
   data_changed_at_range_f on_data_read_at_range;
   data_changed_at_range_f on_data_written_at_range;
-}ring_buffer_t;
+} ring_buffer_t;
 
-#define MEM_RING_BUFFER_STORE(name)   __mem_ring_buffer_store_##name
+#define MEM_RING_BUFFER_STORE(name) __mem_ring_buffer_store_##name
 #define MEM_RING_BUFFER_STORE_T(name) __mem_ring_buffer_store_##name##_t
-#define MEM_RING_BUFFER_STORE_DECL(name, sizeInBytes) \
-typedef struct {\
-  ring_buffer rb;\
-  uint8_t buffer[sizeInBytes]; \
-}MEM_RING_BUFFER_STORE_T(name)
+#define MEM_RING_BUFFER_STORE_DECL(name, sizeInBytes)                                              \
+  typedef struct {                                                                                 \
+    ring_buffer rb;                                                                                \
+    uint8_t buffer[sizeInBytes];                                                                   \
+  } MEM_RING_BUFFER_STORE_T(name)
 
-#define MEM_RING_BUFFER_STORE_DEF(name)\
-MEM_RING_BUFFER_STORE_T(name) MEM_RING_BUFFER_STORE(name)
+#define MEM_RING_BUFFER_STORE_DEF(name) MEM_RING_BUFFER_STORE_T(name) MEM_RING_BUFFER_STORE(name)
 
 typedef struct {
   struct ring_buffer *buffer;
   uint8_t *data;
   uint32_t size_in_bytes;
-}ring_buffer_create_params_t;
+} ring_buffer_create_params_t;
 
-#define MEM_RING_BUFFER_CREATE_PARAMS_INIT(params, name)\
-do {\
-  (params).buffer = &MEM_RING_BUFFER_STORE(name).rb;\
-  (params).data = MEM_RING_BUFFER_STORE(name).buffer;\
-  (params).size_in_bytes = GetArraySize(MEM_RING_BUFFER_STORE(name).buffer);\
-}while(0)
+#define MEM_RING_BUFFER_CREATE_PARAMS_INIT(params, name)                                           \
+  do {                                                                                             \
+    (params).buffer = &MEM_RING_BUFFER_STORE(name).rb;                                             \
+    (params).data = MEM_RING_BUFFER_STORE(name).buffer;                                            \
+    (params).size_in_bytes = GetArraySize(MEM_RING_BUFFER_STORE(name).buffer);                     \
+  } while (0)
 
 /**
  Creates a new memory mapped buffer of the given size.
@@ -168,14 +161,12 @@ do {\
  */
 ring_buffer_ref create_ring_buffer(ring_buffer_create_params_t *params);
 
-
 /**
  Returns the mapped memory and frees the memory used by the buffer. NULL safe.
 
  @param buffer the buffer to free.
  */
 void ring_buffer_release(ring_buffer_ref buffer);
-
 
 /**
  Tests to see if a buffer is empty
@@ -185,7 +176,6 @@ void ring_buffer_release(ring_buffer_ref buffer);
  */
 bool ring_buffer_is_empty(ring_buffer_ref buffer);
 
-
 /**
  Tests to see if a buffer is full
 
@@ -193,7 +183,6 @@ bool ring_buffer_is_empty(ring_buffer_ref buffer);
  @return true if the buffer is full (can't fit anymore data)
  */
 bool ring_buffer_is_full(ring_buffer_ref buffer);
-
 
 /**
  Queries a buffer for its size
@@ -203,7 +192,6 @@ bool ring_buffer_is_full(ring_buffer_ref buffer);
  */
 uint32_t ring_buffer_get_size(ring_buffer_ref buffer);
 
-
 /**
  Gets the entire possible range of the buffer: [readOffset, size]
 
@@ -211,7 +199,6 @@ uint32_t ring_buffer_get_size(ring_buffer_ref buffer);
  @return the current, total range for the buffer
  */
 data_range_t ring_buffer_get_total_range(ring_buffer_ref buffer);
-
 
 /**
  Gets the current valid data range.
@@ -221,15 +208,14 @@ data_range_t ring_buffer_get_total_range(ring_buffer_ref buffer);
  */
 data_range_t ring_buffer_get_current_data_range(ring_buffer_ref buffer);
 
-
 /**
- Gets the total amount of bytes available for reading, that is from the current read position to the end of the valid data.
+ Gets the total amount of bytes available for reading, that is from the current read position to the
+ end of the valid data.
 
  @param buffer the buffer to query
  @return the total amount of bytes available for reading.
  */
 uint32_t ring_buffer_get_bytes_available_for_read(ring_buffer_ref buffer);
-
 
 /**
  Gets the amount of "free" bytes still available in the buffer
@@ -238,7 +224,6 @@ uint32_t ring_buffer_get_bytes_available_for_read(ring_buffer_ref buffer);
  @return the total amount of bytes that can still be written to the buffer.
  */
 uint32_t ring_buffer_get_bytes_available_for_write(ring_buffer_ref buffer);
-
 
 /**
  Writes data into the buffer, if there's space available.
@@ -250,35 +235,36 @@ uint32_t ring_buffer_get_bytes_available_for_write(ring_buffer_ref buffer);
  */
 uint32_t ring_buffer_write_data(ring_buffer_ref buffer, const uint8_t *data, const uint32_t size);
 
-
 /**
  Reads the maximum amount of data available at the given range.
- The returned data can either be empty (data pointers null) or be less data than the requested amount,
- in case the buffer only had a portion of the requested data
+ The returned data can either be empty (data pointers null) or be less data than the requested
+ amount, in case the buffer only had a portion of the requested data
 
  @param buffer the buffer to read from
  @param requested_range range of the data to read
  @param peek if true, the read offset is NOT modified by this read operation.
- @return the requested data. The data is referenced, not copied. See @c MappedData for how to retrieve it.
+ @return the requested data. The data is referenced, not copied. See @c MappedData for how to
+ retrieve it.
  */
-ring_buffer_data_t ring_buffer_get_data_at_range(ring_buffer_ref buffer, data_range_t requested_range, bool peek);
-
+ring_buffer_data_t
+ring_buffer_get_data_at_range(ring_buffer_ref buffer, data_range_t requested_range, bool peek);
 
 /**
  Reads the maximum amount of data available at the current offset (up to length).
- The returned data can either be empty (data pointers null) or be less data than the requested amount,
- in case the buffer only had a portion of the requested data
+ The returned data can either be empty (data pointers null) or be less data than the requested
+ amount, in case the buffer only had a portion of the requested data
 
  @param buffer the buffer to read from
  @param length amount of data to read
  @param peek if true, the read offset is NOT modified by this read operation.
- @return the requested data. The data is referenced, not copied. See @c MappedData for how to retrieve it.
+ @return the requested data. The data is referenced, not copied. See @c MappedData for how to
+ retrieve it.
  */
 ring_buffer_data_t ring_buffer_get_data(ring_buffer_ref buffer, uint32_t length, bool peek);
 
-
 /**
- clears up to length bytes from the buffer. If the data size is less than length the minimum of the two is cleared
+ clears up to length bytes from the buffer. If the data size is less than length the minimum of the
+ two is cleared
 
  @param buffer the buffer to clear from
  @param length amount of data to clear
@@ -293,7 +279,6 @@ void ring_buffer_clear_data(ring_buffer_ref buffer, uint32_t length);
  */
 void ring_buffer_reset_at_offset(ring_buffer_ref buffer, uint32_t offset);
 
-
 /**
  Sets the context that will be passed to callbacks.
 
@@ -307,7 +292,6 @@ void ring_buffer_set_callback_context(ring_buffer_ref buffer, void *ctx);
  */
 void *ring_buffer_get_callback_context(ring_buffer_ref buffer);
 
-
 /**
  If set, will be invoked after each read operation to notify the range of the read data.
 
@@ -315,7 +299,6 @@ void *ring_buffer_get_callback_context(ring_buffer_ref buffer);
  @param callback the callback function to invoke on reads
  */
 void ring_buffer_set_on_read_callback(ring_buffer_ref buffer, data_changed_at_range_f callback);
-
 
 /**
  If set, will be invoked after each write operation to notify the range of the written data.
@@ -325,12 +308,13 @@ void ring_buffer_set_on_read_callback(ring_buffer_ref buffer, data_changed_at_ra
  */
 void ring_buffer_set_on_write_callback(ring_buffer_ref buffer, data_changed_at_range_f callback);
 
-
 /**
  Gets offsets from the mappedBuffer (clever)
  */
-void ring_buffer_get_offsets(ring_buffer_ref buffer, uint32_t *size,
-                             uint32_t *base_read_offset, uint32_t *write_offset);
+void ring_buffer_get_offsets(ring_buffer_ref buffer,
+                             uint32_t *size,
+                             uint32_t *base_read_offset,
+                             uint32_t *write_offset);
 
 #ifdef __cplusplus
 }

--- a/inc/cutils/signal.h
+++ b/inc/cutils/signal.h
@@ -26,29 +26,17 @@
 
 #include <cutils/event_flag.h>
 
-
 typedef event_flag_t signal_t;
 
-static inline bool signal_new(signal_t *p_signal)
-{
-  return event_flag_new(p_signal);
-}
+static inline bool signal_new(signal_t *p_signal) { return event_flag_new(p_signal); }
 
-static inline bool signal_free(signal_t *p_signal)
-{
-  return event_flag_free(p_signal);
-}
+static inline bool signal_free(signal_t *p_signal) { return event_flag_free(p_signal); }
 
-static inline bool signal_wait(signal_t *p_signal)
-{
+static inline bool signal_wait(signal_t *p_signal) {
   return event_flag_wait(p_signal, 1, WAIT_OR_CLEAR, NULL, WAIT_FOREVER);
 }
 
-static inline bool signal_wait_timed(signal_t *p_signal, uint32_t timeout)
-{
+static inline bool signal_wait_timed(signal_t *p_signal, uint32_t timeout) {
   return event_flag_wait(p_signal, 1, WAIT_OR_CLEAR, NULL, timeout);
 }
-static inline bool signal_send(signal_t *p_signal)
-{
-  return event_flag_send(p_signal, 1);
-}
+static inline bool signal_send(signal_t *p_signal) { return event_flag_send(p_signal, 1); }

--- a/inc/cutils/state.h
+++ b/inc/cutils/state.h
@@ -24,9 +24,9 @@
 
 #pragma once
 
-#include <cutils/types.h>
 #include <cutils/klist.h>
 #include <cutils/logger.h>
+#include <cutils/types.h>
 
 // /Forward Declarations
 struct _state_t;
@@ -36,81 +36,82 @@ struct _state_machine_t;
 
 /**
  * The state_init_f callback function is called after the specific state has been created.
- *  
- * The function assumes that the State passed is allocated of 
- * the appropriate type. ie. If you call funtion pointer on say 
- * StateReady type object, you need to pass the same StateReady 
- * object in as a parameter. 
- *  
- *  
- * \param pState State* An allocated and initialized state 
+ *
+ * The function assumes that the State passed is allocated of
+ * the appropriate type. ie. If you call funtion pointer on say
+ * StateReady type object, you need to pass the same StateReady
+ * object in as a parameter.
+ *
+ *
+ * \param pState State* An allocated and initialized state
  *                      sruct.
  */
-typedef void (*state_init_f) (struct _state_machine_t * p_sm, struct _state_t * pState);
+typedef void (*state_init_f)(struct _state_machine_t *p_sm, struct _state_t *pState);
 
 /**
- * Function pointer is called when entering the state. 
- *  
- * \param pState State* A valid state pointer 
+ * Function pointer is called when entering the state.
+ *
+ * \param pState State* A valid state pointer
  */
-typedef void (*state_enter_f) (struct _state_machine_t * p_sm, struct _state_t * pState);
+typedef void (*state_enter_f)(struct _state_machine_t *p_sm, struct _state_t *pState);
 
 /**
  * Funtion pointer is called when exiting the state
- * 
+ *
  * \param pState State* A valid State pointer
  */
-typedef void (*state_exit_f) (struct _state_machine_t * p_sm, struct _state_t * pState);
+typedef void (*state_exit_f)(struct _state_machine_t *p_sm, struct _state_t *pState);
 
 /**
- * Query function which responds true if the event can be 
- * handled by the state. 
- *  
- * \param pState State* A Valid state pointer 
- * \param pEvetn AppEvent* pointer to event received. 
- *  
+ * Query function which responds true if the event can be
+ * handled by the state.
+ *
+ * \param pState State* A Valid state pointer
+ * \param pEvetn AppEvent* pointer to event received.
+ *
  * \return bool True if event can be handled false otherwise.
  */
-typedef bool(*state_is_valid_event_f) (struct _state_machine_t * p_sm, struct _state_t * pState,
+typedef bool (*state_is_valid_event_f)(struct _state_machine_t *p_sm,
+                                       struct _state_t *pState,
                                        void *pEvent);
 
 /**
- * Function pointer to State Event Handler. 
- *  
- * The function handles the incoming event and returns state ID 
- * to transition to. The returned state Id can be the current 
- * state indicating that no state transition is required. 
- *  
- * \param pState State* Pointer to current State 
- * \param pEvent AppEvent* Pointer to received event. 
- *  
- * \return uint32_t A desitination stateId. This can be the 
+ * Function pointer to State Event Handler.
+ *
+ * The function handles the incoming event and returns state ID
+ * to transition to. The returned state Id can be the current
+ * state indicating that no state transition is required.
+ *
+ * \param pState State* Pointer to current State
+ * \param pEvent AppEvent* Pointer to received event.
+ *
+ * \return uint32_t A desitination stateId. This can be the
  *         current stateId as well thus implying no state
  *         transition required.
  */
-typedef uint32_t(*state_handle_event_f) (struct _state_machine_t * p_sm, struct _state_t * pState,
+typedef uint32_t (*state_handle_event_f)(struct _state_machine_t *p_sm,
+                                         struct _state_t *pState,
                                          void *pEvent);
 
 /**
- * \struct State 
- * \brief Data structure that encapsulates an application state. 
- *  
- * The data structure is the base representation of a state 
- * which holds all the generic state handling function pointers. 
- * Specific states should have an instance of this data 
- * structure as the first memeber of their data structure. 
+ * \struct State
+ * \brief Data structure that encapsulates an application state.
+ *
+ * The data structure is the base representation of a state
+ * which holds all the generic state handling function pointers.
+ * Specific states should have an instance of this data
+ * structure as the first memeber of their data structure.
  * eg.
-  
- * typedef struct _StateReady 
+
+ * typedef struct _StateReady
  * {
  *   State base;
  *   bool isReady;
- * }StateReady; 
- *  
- * The data structure can be added to a Klist. Refer to klist.h 
+ * }StateReady;
+ *
+ * The data structure can be added to a Klist. Refer to klist.h
  */
-typedef struct _state_t
-{
+typedef struct _state_t {
   /** List elem so that it can be queued in a list. Must be
    *  first element */
   KListElem listElem;
@@ -143,9 +144,9 @@ typedef struct _state_t
   bool entered_once;
 } state_t;
 
-#define STATE_CLOG(state, p_event, str, ...)\
-console_log(&((state)->log), p_event, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+#define STATE_CLOG(state, p_event, str, ...)                                                       \
+  console_log(&((state)->log), p_event, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
 
-//TODO: Renable this
+// TODO: Renable this
 #define STATE_SLOG(state, p_event, str, ...)
-//system_log(&((state)->log), p_event, "%s(%u)" str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+// system_log(&((state)->log), p_event, "%s(%u)" str, __FUNCTION__, __LINE__, ##__VA_ARGS__)

--- a/inc/cutils/state_event_loop.h
+++ b/inc/cutils/state_event_loop.h
@@ -24,10 +24,10 @@
 
 #pragma once
 
-#include <cutils/state_machine.h>
+#include <cutils/dispatch_queue.h>
 #include <cutils/notifier.h>
 #include <cutils/pool.h>
-#include <cutils/dispatch_queue.h>
+#include <cutils/state_machine.h>
 
 typedef struct _event_t event_t;
 /**
@@ -45,9 +45,9 @@ typedef struct _event_t event_t;
  *
  * The state event loop also offers an api to maintain the listener registrations.
  *
- * Clients will have to implement the set of events that they wish to run through the system. An easy
- * way to do this is to define and enum type and an associated data structure that holds a union of
- * all event data types... ie.
+ * Clients will have to implement the set of events that they wish to run through the system. An
+ * easy way to do this is to define and enum type and an associated data structure that holds a
+ * union of all event data types... ie.
  *
  * enum event_e { EVENT_A, EVENT_B, EVENT_C };
  * struct client_event {
@@ -59,16 +59,15 @@ typedef struct _event_t event_t;
  * };
  *
  */
-typedef struct _state_event_loop_t
-{
-  state_machine_t* p_sm;
+typedef struct _state_event_loop_t {
+  state_machine_t *p_sm;
   uint32_t num_machines;
   dispatch_queue_t *p_exec_queue;
-  pool_t * p_pool_of_events;
-  notifier_t* notifier;
+  pool_t *p_pool_of_events;
+  notifier_t *notifier;
   uint32_t event_data_size;
   logger_t log;
-  char* name;
+  char *name;
   /**
    * @brief This is an optional callback that needs to be installed prior to starting the
    * state_event_loop. This will call a pre processor before any of the states event handling
@@ -77,131 +76,145 @@ typedef struct _state_event_loop_t
    * @param event
    * @param client_data - optional client data typically a pointer to client context.
    */
-  void (*event_pre_proc_f)(event_t* event, void* client_data);
+  void (*event_pre_proc_f)(event_t *event, void *client_data);
   /**
    * @brief Optional client context.
    */
-  void* client_data;
+  void *client_data;
 } state_event_loop_t;
 
 /**
  * @struct state_event_registration_t
  *
- * @brief In order to allow implementations to specify their own listener callback signatures, implementation will
- * have to implement a function which defines the specifics of calling the implementation defined callbacks.
- * This is done by implementers providing a derived type to state_event_registration_t and implementing a notifier function
- * of type `notifier_f` ie void (*notifier_f) (notifier_block_t * pBlock, uint32_t category, void *pNotificationData);
+ * @brief In order to allow implementations to specify their own listener callback signatures,
+ * implementation will have to implement a function which defines the specifics of calling the
+ * implementation defined callbacks. This is done by implementers providing a derived type to
+ * state_event_registration_t and implementing a notifier function of type `notifier_f` ie void
+ * (*notifier_f) (notifier_block_t * pBlock, uint32_t category, void *pNotificationData);
  *
- * Whenever an event is being posted to a listener, the implenting notifier_f is called with a `notifier_block_t` which
- * is a base of `state_event_registration_t` which should be the base of the implmenting registration type. Thus the
- * implementing `notifier_f` can expect its registration which should contain all the mechanics to call the listener
- * functions.
+ * Whenever an event is being posted to a listener, the implenting notifier_f is called with a
+ * `notifier_block_t` which is a base of `state_event_registration_t` which should be the base of
+ * the implmenting registration type. Thus the implementing `notifier_f` can expect its registration
+ * which should contain all the mechanics to call the listener functions.
  */
 
-typedef struct _state_event_registration_t
-{
+typedef struct _state_event_registration_t {
   notifier_block_t base;
   state_event_loop_t *p_event_loop;
 } state_event_registration_t;
 
-typedef struct _event_t
-{
+typedef struct _event_t {
   uint32_t event_id;
   state_event_loop_t *event_loop;
-  uint32_t (*to_string)(struct _event_t* event, char* p_string, uint32_t string_size);
+  uint32_t (*to_string)(struct _event_t *event, char *p_string, uint32_t string_size);
 } event_t;
 
-typedef struct
-{
+typedef struct {
   state_event_loop_t *p_event_loop;
   notifier_create_params_t notifier_create_params;
   dispatch_queue_create_params_t queue_params;
   pool_create_params_t event_pool_create_params;
-  state_machine_create_params_t* p_sm_create_params;
-  state_machine_t* p_sm;
+  state_machine_create_params_t *p_sm_create_params;
+  state_machine_t *p_sm;
   uint32_t num_machines;
   char *name;
   uint32_t exec_queue_priority;
   uint32_t event_data_size;
 } state_event_loop_create_params_t;
 
-#define STATE_EVENT_LOOP_STORE( name )      event_loop_store_##name
-#define STATE_EVENT_LOOP_STORE_T( name )    state_event_loop_store_##name##_t
+#define STATE_EVENT_LOOP_STORE(name) event_loop_store_##name
+#define STATE_EVENT_LOOP_STORE_T(name) state_event_loop_store_##name##_t
 
-#define STATE_EVENT_LOOP_STORE_DECL( name, num_sm, queue_size, max_registrations, max_event_id, stack_size, size_of_notif_block, size_of_posted_event )\
-DISPATCH_QUEUE_STORE_DECL( name, queue_size, stack_size );\
-NOTIFIER_STORE_DECL(name, max_event_id, max_registrations, size_of_notif_block);\
-POOL_STORE_DECL(name, queue_size, size_of_posted_event, sizeof(void*));\
-typedef struct {\
-  state_event_loop_t event_loop;\
-  state_machine_t sm[num_sm];\
-  state_machine_create_params_t sm_create_params[num_sm];\
-}STATE_EVENT_LOOP_STORE_T( name );
+#define STATE_EVENT_LOOP_STORE_DECL(name,                                                          \
+                                    num_sm,                                                        \
+                                    queue_size,                                                    \
+                                    max_registrations,                                             \
+                                    max_event_id,                                                  \
+                                    stack_size,                                                    \
+                                    size_of_notif_block,                                           \
+                                    size_of_posted_event)                                          \
+  DISPATCH_QUEUE_STORE_DECL(name, queue_size, stack_size);                                         \
+  NOTIFIER_STORE_DECL(name, max_event_id, max_registrations, size_of_notif_block);                 \
+  POOL_STORE_DECL(name, queue_size, size_of_posted_event, sizeof(void *));                         \
+  typedef struct {                                                                                 \
+    state_event_loop_t event_loop;                                                                 \
+    state_machine_t sm[num_sm];                                                                    \
+    state_machine_create_params_t sm_create_params[num_sm];                                        \
+  } STATE_EVENT_LOOP_STORE_T(name);
 
-#define STATE_EVENT_LOOP_STORE_DEF( name )\
-static DISPATCH_QUEUE_STORE_DEF( name );\
-static NOTIFIER_STORE_DEF(name);\
-static POOL_STORE_DEF(name);\
-static STATE_EVENT_LOOP_STORE_T( name ) STATE_EVENT_LOOP_STORE( name )
+#define STATE_EVENT_LOOP_STORE_DEF(name)                                                           \
+  static DISPATCH_QUEUE_STORE_DEF(name);                                                           \
+  static NOTIFIER_STORE_DEF(name);                                                                 \
+  static POOL_STORE_DEF(name);                                                                     \
+  static STATE_EVENT_LOOP_STORE_T(name) STATE_EVENT_LOOP_STORE(name)
 
-#define STATE_EVENT_LOOP_CREATE_PARAMS_INIT( params, nm, task_name, task_priority, notifier_f, sm_names, start_states, client_data) do{\
-  memset(&(params), 0, sizeof((params)));\
-  (params).p_event_loop = &STATE_EVENT_LOOP_STORE(nm).event_loop;\
-  (params).p_event_loop->p_sm = STATE_EVENT_LOOP_STORE(nm).sm;\
-  CUTILS_ASSERTF(GetArraySize(sm_names) == GetArraySize(STATE_EVENT_LOOP_STORE(nm).sm),\
-              "Number of state Names(%u) does not match num of state machines (%u)",\
-               GetArraySize(sm_names), GetArraySize(STATE_EVENT_LOOP_STORE(nm).sm));\
-  (params).num_machines = GetArraySize(STATE_EVENT_LOOP_STORE(nm).sm);\
-  (params).p_sm = STATE_EVENT_LOOP_STORE(nm).sm;\
-  (params).p_sm_create_params = STATE_EVENT_LOOP_STORE(nm).sm_create_params;\
-  for(uint32_t iijj = 0; iijj < GetArraySize(sm_names); iijj++ ) {\
-    (params).p_sm_create_params[iijj].p_state_mac = &STATE_EVENT_LOOP_STORE(nm).sm[iijj];\
-    (params).p_sm_create_params[iijj].p_name = sm_names[iijj];\
-    (params).p_sm_create_params[iijj].private_client_data = client_data;\
-    (params).p_sm_create_params[iijj].start_state_id = start_states[iijj];\
-    (params).p_sm_create_params[iijj].should_log = true;\
-    (params).p_sm_create_params[iijj].log_level = 0;\
-  }\
-  (params).name = task_name;\
-  NOTIFIER_STORE_CREATE_PARAMS_INIT((params).notifier_create_params, nm, notifier_f, task_name, true);\
-  DISPATCH_QUEUE_CREATE_PARAMS_INIT((params).queue_params, nm, task_name, task_priority);\
-  POOL_CREATE_INIT((params).event_pool_create_params, nm);\
-  (params).exec_queue_priority = task_priority;\
-  (params).event_data_size = (params).event_pool_create_params.element_size_requested;\
-} while( 0 )
+#define STATE_EVENT_LOOP_CREATE_PARAMS_INIT(                                                       \
+    params, nm, task_name, task_priority, notifier_f, sm_names, start_states, client_data)         \
+  do {                                                                                             \
+    memset(&(params), 0, sizeof((params)));                                                        \
+    (params).p_event_loop = &STATE_EVENT_LOOP_STORE(nm).event_loop;                                \
+    (params).p_event_loop->p_sm = STATE_EVENT_LOOP_STORE(nm).sm;                                   \
+    CUTILS_ASSERTF(GetArraySize(sm_names) == GetArraySize(STATE_EVENT_LOOP_STORE(nm).sm),          \
+                   "Number of state Names(%u) does not match num of state machines (%u)",          \
+                   GetArraySize(sm_names),                                                         \
+                   GetArraySize(STATE_EVENT_LOOP_STORE(nm).sm));                                   \
+    (params).num_machines = GetArraySize(STATE_EVENT_LOOP_STORE(nm).sm);                           \
+    (params).p_sm = STATE_EVENT_LOOP_STORE(nm).sm;                                                 \
+    (params).p_sm_create_params = STATE_EVENT_LOOP_STORE(nm).sm_create_params;                     \
+    for (uint32_t iijj = 0; iijj < GetArraySize(sm_names); iijj++) {                               \
+      (params).p_sm_create_params[iijj].p_state_mac = &STATE_EVENT_LOOP_STORE(nm).sm[iijj];        \
+      (params).p_sm_create_params[iijj].p_name = sm_names[iijj];                                   \
+      (params).p_sm_create_params[iijj].private_client_data = client_data;                         \
+      (params).p_sm_create_params[iijj].start_state_id = start_states[iijj];                       \
+      (params).p_sm_create_params[iijj].should_log = true;                                         \
+      (params).p_sm_create_params[iijj].log_level = 0;                                             \
+    }                                                                                              \
+    (params).name = task_name;                                                                     \
+    NOTIFIER_STORE_CREATE_PARAMS_INIT(                                                             \
+        (params).notifier_create_params, nm, notifier_f, task_name, true);                         \
+    DISPATCH_QUEUE_CREATE_PARAMS_INIT((params).queue_params, nm, task_name, task_priority);        \
+    POOL_CREATE_INIT((params).event_pool_create_params, nm);                                       \
+    (params).exec_queue_priority = task_priority;                                                  \
+    (params).event_data_size = (params).event_pool_create_params.element_size_requested;           \
+  } while (0)
 
-state_event_loop_t *state_event_loop_init(state_event_loop_create_params_t * create_params);
-void state_event_loop_deinit(state_event_loop_t * event_loop);
-void state_event_loop_add_state(state_event_loop_t * event_loop, state_t * state, uint32_t state_mac_id);
+state_event_loop_t *state_event_loop_init(state_event_loop_create_params_t *create_params);
+void state_event_loop_deinit(state_event_loop_t *event_loop);
+void state_event_loop_add_state(state_event_loop_t *event_loop,
+                                state_t *state,
+                                uint32_t state_mac_id);
 /**
- * @brief This allows the client of the state_event_loop to install a callback that is called prior to the
- * states or external listeners processing the event posted. The client can use this to update its global
- * data prior to other entities being notified. This callback must be installed prior to the state_event_loop
- * starting.
+ * @brief This allows the client of the state_event_loop to install a callback that is called prior
+ * to the states or external listeners processing the event posted. The client can use this to
+ * update its global data prior to other entities being notified. This callback must be installed
+ * prior to the state_event_loop starting.
  * @param fn
  * @param client_data - Optional client data, typically a pointer to client context.
  * @return - True if callback successfully installed.
  */
-bool state_event_loop_install_event_pre_proc(state_event_loop_t *event_loop, void (*fn)(event_t *, void *),
+bool state_event_loop_install_event_pre_proc(state_event_loop_t *event_loop,
+                                             void (*fn)(event_t *, void *),
                                              void *client_data);
 void state_event_loop_start(state_event_loop_t *event_loop);
-void state_event_loop_stop(state_event_loop_t * event_loop);
-state_event_registration_t *state_event_loop_allocate_registration(state_event_loop_t * event_loop);
-bool state_event_loop_register_notification(state_event_loop_t * event_loop,
-                                            uint32_t event_type, state_event_registration_t * p_reg);
-void state_event_loop_deregister_notification(state_event_loop_t * event_loop,
-                                              state_event_registration_t * p_reg);
-uint32_t state_event_loop_get_current_state_id(state_event_loop_t* event_loop, uint32_t state_mac_index);
-state_t* state_event_loop_get_current_state(state_event_loop_t* event_loop, uint32_t state_mac_index);
+void state_event_loop_stop(state_event_loop_t *event_loop);
+state_event_registration_t *state_event_loop_allocate_registration(state_event_loop_t *event_loop);
+bool state_event_loop_register_notification(state_event_loop_t *event_loop,
+                                            uint32_t event_type,
+                                            state_event_registration_t *p_reg);
+void state_event_loop_deregister_notification(state_event_loop_t *event_loop,
+                                              state_event_registration_t *p_reg);
+uint32_t state_event_loop_get_current_state_id(state_event_loop_t *event_loop,
+                                               uint32_t state_mac_index);
+state_t *state_event_loop_get_current_state(state_event_loop_t *event_loop,
+                                            uint32_t state_mac_index);
 
 /**
- * @brief - will allocate the an event from the pool maintained internally in the event_loop. Clients can
- * use this as part of their event post routines.
+ * @brief - will allocate the an event from the pool maintained internally in the event_loop.
+ * Clients can use this as part of their event post routines.
  * @param event_loop - an initialized and running event loop
  * @return
  */
-static inline event_t *state_event_loop_allocate_event(state_event_loop_t * event_loop)
-{
+static inline event_t *state_event_loop_allocate_event(state_event_loop_t *event_loop) {
   event_t *retval = 0;
 
   if (event_loop) {
@@ -217,9 +230,8 @@ static inline event_t *state_event_loop_allocate_event(state_event_loop_t * even
  * @param event_loop - an initialized and running event loop
  * @param event
  */
-static inline void state_event_loop_retain_event(state_event_loop_t* event_loop, event_t* event)
-{
-  CUTILS_ASSERTF( event_loop && event, "Invalid Inputs" );
+static inline void state_event_loop_retain_event(state_event_loop_t *event_loop, event_t *event) {
+  CUTILS_ASSERTF(event_loop && event, "Invalid Inputs");
   pool_retain(event_loop->p_pool_of_events, event);
 }
 
@@ -229,9 +241,8 @@ static inline void state_event_loop_retain_event(state_event_loop_t* event_loop,
  * @param event_loop
  * @param event
  */
-static inline void state_event_loop_release_event(state_event_loop_t* event_loop, event_t* event)
-{
-  CUTILS_ASSERTF( event_loop && event, "Invalid Inputs" );
+static inline void state_event_loop_release_event(state_event_loop_t *event_loop, event_t *event) {
+  CUTILS_ASSERTF(event_loop && event, "Invalid Inputs");
   pool_free(event_loop->p_pool_of_events, event);
 }
 
@@ -242,8 +253,8 @@ static inline void state_event_loop_release_event(state_event_loop_t* event_loop
  * @param evt
  * @return
  */
-static inline bool state_event_loop_post(state_event_loop_t * event_loop, uint32_t category, event_t * evt)
-{
+static inline bool
+state_event_loop_post(state_event_loop_t *event_loop, uint32_t category, event_t *evt) {
   bool retval = false;
 
   void state_event_loop_exec_queue_f(void *arg1, void *arg2);
@@ -255,15 +266,18 @@ static inline bool state_event_loop_post(state_event_loop_t * event_loop, uint32
     event->event_loop = event_loop;
     event->event_id = category;
     event->to_string = evt->to_string;
-    //TODO: Reenable This
-    //system_log(&event_loop->log, event, "%s(%u): Posting" , __FUNCTION__, __LINE__);
+    // TODO: Reenable This
+    // system_log(&event_loop->log, event, "%s(%u): Posting" , __FUNCTION__, __LINE__);
     dispatch_async_f(event_loop->p_exec_queue, state_event_loop_exec_queue_f, event, NULL);
     retval = true;
   }
   return retval;
 }
 
-uint32_t state_event_loop_state_prefix(logger_t* p_logger, void* p_private, char* p_string, uint32_t string_size);
+uint32_t state_event_loop_state_prefix(logger_t *p_logger,
+                                       void *p_private,
+                                       char *p_string,
+                                       uint32_t string_size);
 
 /**
  *  Macro to initalize a state data structure.
@@ -277,19 +291,16 @@ uint32_t state_event_loop_state_prefix(logger_t* p_logger, void* p_private, char
  *  \param handleEvent: state_handle_event_f - event handler
  *  \param logging: bool - Logging Enabled/Disabled
  */
-#define STATE_INITIALIZER( stId, stateName, init, Enter, Exit, validEvent, handleEvent )\
-{\
-  .listElem = { 0 },\
-  .stateId = stId,\
-  .state_name = stateName,\
-  .f_init = init,\
-  .f_enter = Enter,\
-  .f_exit = Exit,\
-  .f_valid_event = validEvent,\
-  .f_handle_event = handleEvent,\
-  .entered_once = false,\
-  .log.fnPrefix = state_event_loop_state_prefix,\
-  .log.isEnabled = true,\
-  .log.log_level = 0\
-}
-
+#define STATE_INITIALIZER(stId, stateName, init, Enter, Exit, validEvent, handleEvent)             \
+  {.listElem = {0},                                                                                \
+   .stateId = stId,                                                                                \
+   .state_name = stateName,                                                                        \
+   .f_init = init,                                                                                 \
+   .f_enter = Enter,                                                                               \
+   .f_exit = Exit,                                                                                 \
+   .f_valid_event = validEvent,                                                                    \
+   .f_handle_event = handleEvent,                                                                  \
+   .entered_once = false,                                                                          \
+   .log.fnPrefix = state_event_loop_state_prefix,                                                  \
+   .log.isEnabled = true,                                                                          \
+   .log.log_level = 0}

--- a/inc/cutils/state_machine.h
+++ b/inc/cutils/state_machine.h
@@ -26,23 +26,22 @@
 
 #include "state.h"
 /** Maximum number of states that a state machine can have. */
-#define STATE_MAC_MAX_STATES        20
+#define STATE_MAC_MAX_STATES 20
 
 /**
- * \struct StateMachine 
- * \brief Encapsulates a state machine 
- *  
- * This data structure encapsulates data specific to a state 
- * machine. A state machine contains an array of state pointers, 
- * which are registered with the state machine during the state 
- * machine's configuration. The configuration steps include 
- * 1) Create the state machine 
- * 2) Configure the State machine with all the states 
- * 3) Start the state machine. 
- *  
+ * \struct StateMachine
+ * \brief Encapsulates a state machine
+ *
+ * This data structure encapsulates data specific to a state
+ * machine. A state machine contains an array of state pointers,
+ * which are registered with the state machine during the state
+ * machine's configuration. The configuration steps include
+ * 1) Create the state machine
+ * 2) Configure the State machine with all the states
+ * 3) Start the state machine.
+ *
  */
-typedef struct _state_machine_t
-{
+typedef struct _state_machine_t {
   char *p_name;
   /** Number of states in the state machine. Used when
    *  iterating through state array */
@@ -65,100 +64,98 @@ typedef struct _state_machine_t
   logger_t logger;
 } state_machine_t;
 
-typedef struct _state_machine_create_params_t
-{
-  state_machine_t* p_state_mac;
-  char* p_name;
-  void* private_client_data;
+typedef struct _state_machine_create_params_t {
+  state_machine_t *p_state_mac;
+  char *p_name;
+  void *private_client_data;
   uint32_t start_state_id;
   bool should_log;
   uint32_t log_level;
-}state_machine_create_params_t;
+} state_machine_create_params_t;
 
-
-state_machine_t* state_machine_create(state_machine_create_params_t *params);
+state_machine_t *state_machine_create(state_machine_create_params_t *params);
 
 /**
- * State specific event handler 
- *  
- * The function will call the state specific event handler and 
- * will latch any state transition requested. 
- * 
- * 
+ * State specific event handler
+ *
+ * The function will call the state specific event handler and
+ * will latch any state transition requested.
+ *
+ *
  * @param pStateMac: StateMachine* - pointer to valid state
  *                 machine that has been started.
- * @param pEvent: AppEvent* - pointer to valid Event 
+ * @param pEvent: AppEvent* - pointer to valid Event
  */
-void state_machine_handle_event(state_machine_t * state_mac, void *event);
+void state_machine_handle_event(state_machine_t *state_mac, void *event);
 
 /**
  * Register state with state machine.
- *  
- * The function registers a fully allocated and initialized 
- * state with the state machine. Should be called before 
- * starting the state machine. 
- * 
- * 
- * @param pStateMac: StateMachine* - Pointer to valid state 
+ *
+ * The function registers a fully allocated and initialized
+ * state with the state machine. Should be called before
+ * starting the state machine.
+ *
+ *
+ * @param pStateMac: StateMachine* - Pointer to valid state
  *                 machine
- * @param pState: State* - Pointer to valid State 
+ * @param pState: State* - Pointer to valid State
  */
-void state_machine_register_state(state_machine_t * state_mac, state_t * state);
+void state_machine_register_state(state_machine_t *state_mac, state_t *state);
 
-/** 
- * Get state for requested stateId from state machine 
- *   
+/**
+ * Get state for requested stateId from state machine
+ *
  *  Returns the State* structure for the requested stateId
  *  (based on what was registered), from the provided state
  *  machine.
- *  
- * @param pStateMac: StateMachine* - pointer to valid state 
+ *
+ * @param pStateMac: StateMachine* - pointer to valid state
  *                 machine
- * @param stateId: uint32_t - valid state Id. 
- * 
+ * @param stateId: uint32_t - valid state Id.
+ *
  * @return State* - pointer to state structure requested or NULL
  *         if not found.
  */
-state_t *state_machine_get_state(state_machine_t * state_mac, uint32_t state_id);
+state_t *state_machine_get_state(state_machine_t *state_mac, uint32_t state_id);
 
 /**
- * Start the state machine. 
- *  
- * This will load the Inital state into the state machine and 
- * thus hook it up to the event handler. 
- * 
- * 
- * @param pStateMac: StateMachine* - pointer to valid state 
+ * Start the state machine.
+ *
+ * This will load the Inital state into the state machine and
+ * thus hook it up to the event handler.
+ *
+ *
+ * @param pStateMac: StateMachine* - pointer to valid state
  *                 machine
  * @param initialState: uint32_t - valid initial state id.
  */
 void state_machine_start(state_machine_t *state_mac);
 
 /**
- * StateMachineStop - This will stop the state machine. All 
- * subsequent events posted will be discarded. Calling this is 
- * not so simple. You should call this in the same context that 
- * the State Machine Events are handled, or you have to 
- * synchronoize between the state machine event hander thread 
- * and the poster of this. This will effectively stop the state 
- * machine from engaging.  
- * 
- * 
- * @param pStateMac -  
+ * StateMachineStop - This will stop the state machine. All
+ * subsequent events posted will be discarded. Calling this is
+ * not so simple. You should call this in the same context that
+ * the State Machine Events are handled, or you have to
+ * synchronoize between the state machine event hander thread
+ * and the poster of this. This will effectively stop the state
+ * machine from engaging.
+ *
+ *
+ * @param pStateMac -
  */
-void state_machine_stop(state_machine_t * state_mac);
+void state_machine_stop(state_machine_t *state_mac);
 
 /**
  * Executes state transition.
- * 
+ *
  *  Will execute a state transition if one is requested. The
  *  function is called by the event handler when it is ready to
  *  execute a state transition.
- *  
- * @param pStateMac: StateMachine* - pointer to valid state 
+ *
+ * @param pStateMac: StateMachine* - pointer to valid state
  *                 machine.
  */
-void state_machine_transition(state_machine_t * state_mac);
+void state_machine_transition(state_machine_t *state_mac);
 
 /**
  * @brief States machines can be supplied with client data which can retrieved
@@ -167,7 +164,7 @@ void state_machine_transition(state_machine_t * state_mac);
  * @param state_mac - A Valid State Machine
  * @return void* - NULL if no private data or the private data supplied in the create params
  */
-void* state_machine_get_private_data(state_machine_t* state_mac);
+void *state_machine_get_private_data(state_machine_t *state_mac);
 
 /**
  * @brief Clients supply private data to the state machine using this API. This can be retrieved
@@ -175,4 +172,4 @@ void* state_machine_get_private_data(state_machine_t* state_mac);
  * @param state_mac - Valid State machine pointer
  * @param private - Private data
  */
-void state_machine_set_private_data(state_machine_t* state_mac, void* private);
+void state_machine_set_private_data(state_machine_t *state_mac, void *private);

--- a/inc/cutils/ts_log_buffer.h
+++ b/inc/cutils/ts_log_buffer.h
@@ -29,17 +29,16 @@
 #include <stdarg.h>
 #include <string.h>
 
-
 /**
  * @file ts_log_buffer.h
- * This file provides a thread safe API around log_buffers. It also allows clients to register notifications for
- * log buffer size events.
+ * This file provides a thread safe API around log_buffers. It also allows clients to register
+ * notifications for log buffer size events.
  */
 
-#define LOG_BUF_NOTIF(XX)\
-  XX( LB_FULL, )\
-  XX( LB_ALMOST_FULL, )\
-  XX( LB_EMPTY, )\
+#define LOG_BUF_NOTIF(XX)                                                                          \
+  XX(LB_FULL, )                                                                                    \
+  XX(LB_ALMOST_FULL, )                                                                             \
+  XX(LB_EMPTY, )
 
 DECLARE_ENUM(ts_log_buffer_notfication_e, LOG_BUF_NOTIF)
 
@@ -49,11 +48,11 @@ struct _ts_log_buffer_t;
  * @brief this callback signature allows clients to be notified when the log buffer hits certain
  * size thresholds.
  */
-typedef void (*ts_log_buffer_f)(struct _ts_log_buffer_t *pLb, ts_log_buffer_notfication_e notif,
+typedef void (*ts_log_buffer_f)(struct _ts_log_buffer_t *pLb,
+                                ts_log_buffer_notfication_e notif,
                                 void *private);
 
-typedef struct _ts_log_buffer_t
-{
+typedef struct _ts_log_buffer_t {
   log_buffer_t lb;
   mutex_t mtx;
   ts_log_buffer_f fn;
@@ -91,14 +90,18 @@ void ts_log_buffer_push(ts_log_buffer_t *p_ts_log, char *string, uint32_t string
  * @param fn - callback
  * @param private - callback context
  */
-void ts_log_buffer_install_notifications(ts_log_buffer_t *p_ts_log, ts_log_buffer_f fn, void *private);
+void ts_log_buffer_install_notifications(ts_log_buffer_t *p_ts_log,
+                                         ts_log_buffer_f fn,
+                                         void *private);
 
 /**
  * @brief Returns the current size of the log_buffer.
  * @param p_lb - Initialized Log Buffer
  * @param initial_bytes - If there is no wrap around, this is the total byte size
- * @param residual_bytes - If a wrap around occurs, this is the number of bytes from the head of the buffer to the last
- *                          character inserted
+ * @param residual_bytes - If a wrap around occurs, this is the number of bytes from the head of the
+ * buffer to the last character inserted
  * @return
  */
-uint32_t ts_log_buffer_current_size(ts_log_buffer_t *p_lb, uint32_t *initial_bytes, uint32_t *residual_bytes);
+uint32_t ts_log_buffer_current_size(ts_log_buffer_t *p_lb,
+                                    uint32_t *initial_bytes,
+                                    uint32_t *residual_bytes);

--- a/inc/cutils/types.h
+++ b/inc/cutils/types.h
@@ -28,78 +28,77 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include <stdint.h>
-#include <stdbool.h>
 #include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
 
-#define GetArraySize(x)                   ((sizeof((x)))/(sizeof((x)[0])))
+#define GetArraySize(x) ((sizeof((x))) / (sizeof((x)[0])))
 
 #ifndef MIN
-#    define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
 #ifndef MAX
-#    define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 #ifndef CUTILS_ASSERT
-#define CUTILS_ASSERT(x) {\
-  if(!(x)) {\
-    *((volatile char *)0) = 1;\
-  }\
-}
+#define CUTILS_ASSERT(x)                                                                           \
+  {                                                                                                \
+    if (!(x)) {                                                                                    \
+      *((volatile char *)0) = 1;                                                                   \
+    }                                                                                              \
+  }
 #endif
 
 // expansion macro for enum value definition
-#define ENUM_VALUE( name, assign ) name assign,
+#define ENUM_VALUE(name, assign) name assign,
 
 // expansion macro for enum to string conversion
-#define ENUM_CASE( name, assign ) case name: return #name;
+#define ENUM_CASE(name, assign)                                                                    \
+  case name:                                                                                       \
+    return #name;
 
-#define ENUM_STRCMP( name, assign ) if( !strcmp( str, #name ) ) return name;
+#define ENUM_STRCMP(name, assign)                                                                  \
+  if (!strcmp(str, #name))                                                                         \
+    return name;
 
 // declare the access function and enum values
-#define DECLARE_ENUM( EnumType, ENUM_DEF ) \
-  typedef enum _##EnumType { \
-    ENUM_DEF( ENUM_VALUE ) \
-  }EnumType;\
-  static inline const char* get_##EnumType##_string( EnumType blah )\
-  {\
-     switch( blah ) {\
-       ENUM_DEF(ENUM_CASE)\
-       default: return "";\
-     }\
-  }\
-  static inline EnumType get_##EnumType##_value( const char* str )\
-  {\
-     ENUM_DEF(ENUM_STRCMP)\
-     return (EnumType)0;\
+#define DECLARE_ENUM(EnumType, ENUM_DEF)                                                           \
+  typedef enum _##EnumType{ENUM_DEF(ENUM_VALUE)} EnumType;                                         \
+  static inline const char *get_##EnumType##_string(EnumType blah) {                               \
+    switch (blah) {                                                                                \
+      ENUM_DEF(ENUM_CASE)                                                                          \
+    default:                                                                                       \
+      return "";                                                                                   \
+    }                                                                                              \
+  }                                                                                                \
+  static inline EnumType get_##EnumType##_value(const char *str) {                                 \
+    ENUM_DEF(ENUM_STRCMP)                                                                          \
+    return (EnumType)0;                                                                            \
   }
 
-#define DECLARE_ENUM_NONINLINE( EnumType, ENUM_DEF )\
-  typedef enum _##EnumType { \
-    ENUM_DEF( ENUM_VALUE ) \
-  }EnumType;\
-  const char* get_##EnumType##_string( EnumType blah );\
-  EnumType get_##EnumType##_value( const char* str );
+#define DECLARE_ENUM_NONINLINE(EnumType, ENUM_DEF)                                                 \
+  typedef enum _##EnumType{ENUM_DEF(ENUM_VALUE)} EnumType;                                         \
+  const char *get_##EnumType##_string(EnumType blah);                                              \
+  EnumType get_##EnumType##_value(const char *str);
 
-#define DEFINE_ENUM_STRINGIFY( EnumType, ENUM_DEF )\
-  const char* get_##EnumType##_string( EnumType blah )\
-  {\
-     switch( blah ) {\
-       ENUM_DEF(ENUM_CASE)\
-       default: return "";\
-     }\
-  }\
-  EnumType get_##EnumType##_value( const char* str )\
-  {\
-     ENUM_DEF(ENUM_STRCMP)\
-     return (EnumType)0;\
+#define DEFINE_ENUM_STRINGIFY(EnumType, ENUM_DEF)                                                  \
+  const char *get_##EnumType##_string(EnumType blah) {                                             \
+    switch (blah) {                                                                                \
+      ENUM_DEF(ENUM_CASE)                                                                          \
+    default:                                                                                       \
+      return "";                                                                                   \
+    }                                                                                              \
+  }                                                                                                \
+  EnumType get_##EnumType##_value(const char *str) {                                               \
+    ENUM_DEF(ENUM_STRCMP)                                                                          \
+    return (EnumType)0;                                                                            \
   }
 
 // Other system wide constants and macros
-#define LOG_MAX_LINE_LENGTH             (512)
+#define LOG_MAX_LINE_LENGTH (512)
 
 #ifdef __cplusplus
 };
 #endif
-#endif //CUTILS_TYPES_H
+#endif // CUTILS_TYPES_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,64 +1,68 @@
-enable_language( C )
-file( GLOB HEADER_LIST CONFIGURE_DEPENDS "${cutils_SOURCE_DIR}/inc/cutils/*.h" )
+enable_language(C)
+file(GLOB HEADER_LIST CONFIGURE_DEPENDS "${cutils_SOURCE_DIR}/inc/cutils/*.h")
 
-#Configure the platform specific stuff
-#Currently only C11 APIs supported
-set( CUTILS_PLATFORM_TYPE pthread CACHE STRING "cutils OS abstraction platform (pthread|c11)")
-set_property( CACHE CUTILS_PLATFORM_TYPE PROPERTY STRINGS pthread c11 )
-if(NOT "${CUTILS_PLATFORM_TYPE}" STREQUAL "pthread" AND
-   NOT "${CUTILS_PLATFORM_TYPE}" STREQUAL "c11")
-  message(FATAL_ERROR
-          "CUTILS_PLATFORM_TYPE must be 'pthread' or 'c11', got '${CUTILS_PLATFORM_TYPE}'")
+# Configure the platform specific stuff Currently only C11 APIs supported
+set(CUTILS_PLATFORM_TYPE
+    pthread
+    CACHE STRING "cutils OS abstraction platform (pthread|c11)")
+set_property(CACHE CUTILS_PLATFORM_TYPE PROPERTY STRINGS pthread c11)
+if(NOT "${CUTILS_PLATFORM_TYPE}" STREQUAL "pthread" AND NOT "${CUTILS_PLATFORM_TYPE}" STREQUAL
+                                                        "c11")
+  message(
+    FATAL_ERROR "CUTILS_PLATFORM_TYPE must be 'pthread' or 'c11', got '${CUTILS_PLATFORM_TYPE}'")
 endif()
-set( TEMPLATE_HEADER_LOCATION ${cutils_SOURCE_DIR}/inc )
+set(TEMPLATE_HEADER_LOCATION ${cutils_SOURCE_DIR}/inc)
 
-configure_file( ${TEMPLATE_HEADER_LOCATION}/cutils/mutex.h.in ${PROJECT_BINARY_DIR}/inc/cutils/mutex.h )
-configure_file( ${TEMPLATE_HEADER_LOCATION}/cutils/task.h.in ${PROJECT_BINARY_DIR}/inc/cutils/task.h )
-configure_file( ${TEMPLATE_HEADER_LOCATION}/cutils/event_flag.h.in ${PROJECT_BINARY_DIR}/inc/cutils/event_flag.h )
-configure_file( ${TEMPLATE_HEADER_LOCATION}/cutils/ts_queue.h.in ${PROJECT_BINARY_DIR}/inc/cutils/ts_queue.h)
+configure_file(${TEMPLATE_HEADER_LOCATION}/cutils/mutex.h.in
+               ${PROJECT_BINARY_DIR}/inc/cutils/mutex.h)
+configure_file(${TEMPLATE_HEADER_LOCATION}/cutils/task.h.in ${PROJECT_BINARY_DIR}/inc/cutils/task.h)
+configure_file(${TEMPLATE_HEADER_LOCATION}/cutils/event_flag.h.in
+               ${PROJECT_BINARY_DIR}/inc/cutils/event_flag.h)
+configure_file(${TEMPLATE_HEADER_LOCATION}/cutils/ts_queue.h.in
+               ${PROJECT_BINARY_DIR}/inc/cutils/ts_queue.h)
 
-function( print_list theList )
-  foreach( item ${theList} )
+function(print_list theList)
+  foreach(item ${theList})
     message("${item}")
   endforeach()
 endfunction()
 # set up options
-option( USE_STD_PRINTF
-        "Use the std lib provided printf function for debug output"
-        ON )
-if( USE_STD_PRINTF )
-  add_definitions( -DUSE_STD_PRINTF )
+option(USE_STD_PRINTF "Use the std lib provided printf function for debug output" ON)
+if(USE_STD_PRINTF)
+  add_definitions(-DUSE_STD_PRINTF)
 endif()
 
 # Build the logger common stuff.
-add_library( logger_basic logger.c)
+add_library(logger_basic logger.c)
 target_compile_definitions(logger_basic PUBLIC c_std_11)
 target_include_directories(logger_basic PUBLIC ${API_INCLUDES})
 
-if( "${CUTILS_PLATFORM_TYPE}" STREQUAL "c11" )
-  add_subdirectory( c11 )
+if("${CUTILS_PLATFORM_TYPE}" STREQUAL "c11")
+  add_subdirectory(c11)
 elseif("${CUTILS_PLATFORM_TYPE}" STREQUAL "pthread")
   add_subdirectory(pthread)
 else()
-  message( FATAL_ERROR "Need a proper cutils platform type" )
+  message(FATAL_ERROR "Need a proper cutils platform type")
 endif()
 
-set( SOURCES
-     asyncio.c
-     bst.c
-     dispatch_queue.c
-     endian.c
-     log_buffer.c
-     notifier.c
-     ring_buffer.c
-     state_event_loop.c
-     state_machine.c
-     ts_log_buffer.c)
+set(SOURCES
+    asyncio.c
+    bst.c
+    dispatch_queue.c
+    endian.c
+    log_buffer.c
+    notifier.c
+    ring_buffer.c
+    state_event_loop.c
+    state_machine.c
+    ts_log_buffer.c)
 
-add_library( cutils ${SOURCES} ${HEADER_LIST} )
-target_include_directories( cutils PUBLIC ${API_INCLUDES} )
-target_compile_features( cutils PUBLIC c_std_11 )
-target_link_libraries( cutils logger_basic platform_abstraction )
+add_library(cutils ${SOURCES} ${HEADER_LIST})
+target_include_directories(cutils PUBLIC ${API_INCLUDES})
+target_compile_features(cutils PUBLIC c_std_11)
+target_link_libraries(cutils logger_basic platform_abstraction)
 
-source_group( TREE "${PROJECT_SOURCE_DIR}/inc" PREFIX "Header Files" FILES ${HEADER_LIST} )
-
+source_group(
+  TREE "${PROJECT_SOURCE_DIR}/inc"
+  PREFIX "Header Files"
+  FILES ${HEADER_LIST})

--- a/src/asyncio.c
+++ b/src/asyncio.c
@@ -29,7 +29,7 @@
 // Tx Dispatch action prototype
 static void tx_f(void *arg1, void *arg2);
 // Rx Dispatch action Prototype
-static void rx_f(void* arg1, void* arg2);
+static void rx_f(void *arg1, void *arg2);
 
 // Other static Prototypes
 
@@ -46,46 +46,56 @@ static bool asyncio_start_tx_thread(asyncio_interface_instance_t *p_asyncio);
 
 static bool asyncio_start_rx_thread(asyncio_interface_instance_t *p_asyncio);
 
-//TODO: Enable this when System log has been integrated
+// TODO: Enable this when System log has been integrated
 #define STREAM_SLOG(str, ...)
-//system_log( &p_asyncio->log, NULL, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+// system_log( &p_asyncio->log, NULL, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
 
-#define STREAM_CLOG(str, ...)\
-console_log( &p_asyncio->log, NULL, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+#define STREAM_CLOG(str, ...)                                                                      \
+  console_log(&p_asyncio->log, NULL, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
 
-#define  STREAM_CLOGV(str, ...)\
-LOG_IF(STREAM_CLOG, p_asyncio->log.log_level, str, ##__VA_ARGS__ )
+#define STREAM_CLOGV(str, ...) LOG_IF(STREAM_CLOG, p_asyncio->log.log_level, str, ##__VA_ARGS__)
 
-#define STREAM_STARTED_FLAG       (1 << 0)
-#define STREAM_STOPPED_FLAG       (1 << 1)
+#define STREAM_STARTED_FLAG (1 << 0)
+#define STREAM_STOPPED_FLAG (1 << 1)
 
-static uint32_t asyncio_logger_prefix(logger_t* logger, void *client_data, char *string, uint32_t string_size)
-{
+static uint32_t
+asyncio_logger_prefix(logger_t *logger, void *client_data, char *string, uint32_t string_size) {
   uint32_t retval = 0;
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t*)((size_t)logger - offsetof(asyncio_interface_instance_t, log));
+  asyncio_interface_instance_t *p_asyncio =
+      (asyncio_interface_instance_t *)((size_t)logger -
+                                       offsetof(asyncio_interface_instance_t, log));
 
-  if( string_size > 30) {
-    INSERT_TO_STRING(string, retval, "%s:%s(Tx:%s,Rx:%s)",
-        p_asyncio->stream_name,
-        get_asyncio_init_state_e_string(atomic_load(&p_asyncio->init_state)),
-        get_asyncio_init_state_e_string(atomic_load(&p_asyncio->tx_task.init_state)),
-        get_asyncio_init_state_e_string(atomic_load(&p_asyncio->rx_task.init_state)));
+  if (string_size > 30) {
+    INSERT_TO_STRING(string,
+                     retval,
+                     "%s:%s(Tx:%s,Rx:%s)",
+                     p_asyncio->stream_name,
+                     get_asyncio_init_state_e_string(atomic_load(&p_asyncio->init_state)),
+                     get_asyncio_init_state_e_string(atomic_load(&p_asyncio->tx_task.init_state)),
+                     get_asyncio_init_state_e_string(atomic_load(&p_asyncio->rx_task.init_state)));
   }
   return retval;
 }
 
-asyncio_handle_t asyncio_create_instance(asyncio_create_params_t *p_params)
-{
+asyncio_handle_t asyncio_create_instance(asyncio_create_params_t *p_params) {
   asyncio_interface_instance_t *p_asyncio = NULL;
-  CUTILS_ASSERTF(p_params->p_instance &&
-               ((p_params->read_f && p_params->rx_callback) || p_params->write_f) &&
-               ((p_params->read_f && p_params->rx_callback) || (!p_params->read_f && !p_params->rx_callback)),
-               "Invalid stream creation parameters, Inst = %p, read_f = %p, rx_cb = %p, write_f = %p",
-               p_params->p_instance, p_params->read_f, p_params->rx_callback, p_params->write_f);
+  CUTILS_ASSERTF(
+      p_params->p_instance && ((p_params->read_f && p_params->rx_callback) || p_params->write_f) &&
+          ((p_params->read_f && p_params->rx_callback) ||
+           (!p_params->read_f && !p_params->rx_callback)),
+      "Invalid stream creation parameters, Inst = %p, read_f = %p, rx_cb = %p, write_f = %p",
+      p_params->p_instance,
+      p_params->read_f,
+      p_params->rx_callback,
+      p_params->write_f);
 
-  CUTILS_ASSERTF((p_params->rx_worker && p_params->read_f) || (p_params->tx_worker && p_params->write_f),
-               "Appropriate Dispatch Queues not provided, rx_dq: %p, read_f: %p, tx_dq: %p, write_f: %p",
-               p_params->rx_worker, p_params->read_f, p_params->tx_worker, p_params->write_f);
+  CUTILS_ASSERTF(
+      (p_params->rx_worker && p_params->read_f) || (p_params->tx_worker && p_params->write_f),
+      "Appropriate Dispatch Queues not provided, rx_dq: %p, read_f: %p, tx_dq: %p, write_f: %p",
+      p_params->rx_worker,
+      p_params->read_f,
+      p_params->tx_worker,
+      p_params->write_f);
   p_asyncio = p_params->p_instance;
 
   CUTILS_ASSERTF(event_flag_new(&p_asyncio->event_flag), "Couldn't create event flag");
@@ -102,9 +112,8 @@ asyncio_handle_t asyncio_create_instance(asyncio_create_params_t *p_params)
   return p_asyncio;
 }
 
-void asyncio_destroy_instance(asyncio_handle_t h_asyncio)
-{
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *) h_asyncio;
+void asyncio_destroy_instance(asyncio_handle_t h_asyncio) {
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)h_asyncio;
   if (p_asyncio) {
     asyncio_stop(p_asyncio);
     event_flag_free(&p_asyncio->event_flag);
@@ -113,9 +122,8 @@ void asyncio_destroy_instance(asyncio_handle_t h_asyncio)
   }
 }
 
-bool asyncio_start(asyncio_handle_t h_asyncio)
-{
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *) h_asyncio;
+bool asyncio_start(asyncio_handle_t h_asyncio) {
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)h_asyncio;
   bool retval = true;
   int expected = AsyncioUninitialized;
 
@@ -143,23 +151,24 @@ bool asyncio_start(asyncio_handle_t h_asyncio)
 
     p_asyncio->stream_stopped = false;
     if (retval) {
-      CUTILS_ASSERTF(event_flag_wait(&p_asyncio->event_flag, STREAM_STARTED_FLAG, WAIT_OR, NULL, 4000),
-                   "Failed to wait on Started Flag");
+      CUTILS_ASSERTF(
+          event_flag_wait(&p_asyncio->event_flag, STREAM_STARTED_FLAG, WAIT_OR, NULL, 4000),
+          "Failed to wait on Started Flag");
       STREAM_SLOG("Started");
       STREAM_CLOGV("Started");
     } else {
       atomic_store(&p_asyncio->init_state, AsyncioUninitialized);
     }
   } else {
-    CLOG("Init State is bad %s", get_asyncio_init_state_e_string(atomic_load(&p_asyncio->init_state)));
+    CLOG("Init State is bad %s",
+         get_asyncio_init_state_e_string(atomic_load(&p_asyncio->init_state)));
     retval = false;
   }
   return retval;
 }
 
-void asyncio_stop(asyncio_handle_t h_asyncio)
-{
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *) h_asyncio;
+void asyncio_stop(asyncio_handle_t h_asyncio) {
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)h_asyncio;
   int expected = AsyncioInitialized;
   if (atomic_compare_exchange_strong(&p_asyncio->init_state, &expected, AsyncioUninitializing)) {
     if (!p_asyncio->stream_stopped) {
@@ -167,24 +176,25 @@ void asyncio_stop(asyncio_handle_t h_asyncio)
       p_asyncio->stream_stopped = true;
       asyncio_stop_rx_thread(p_asyncio);
       asyncio_stop_tx_thread(p_asyncio);
-      CUTILS_ASSERTF(event_flag_wait(&p_asyncio->event_flag, STREAM_STOPPED_FLAG, WAIT_OR, NULL, 4000),
+      CUTILS_ASSERTF(
+          event_flag_wait(&p_asyncio->event_flag, STREAM_STOPPED_FLAG, WAIT_OR, NULL, 4000),
           "Failed to wait on Stopped Flag");
       STREAM_SLOG("Stopped");
       STREAM_CLOGV("Stopped");
     }
   } else {
-    STREAM_SLOG("Failed: State = %s", get_asyncio_init_state_e_string(atomic_load(&p_asyncio->init_state)));
+    STREAM_SLOG("Failed: State = %s",
+                get_asyncio_init_state_e_string(atomic_load(&p_asyncio->init_state)));
   }
 }
 
-asyncio_tx_token_t asyncio_allocate_tx_token(asyncio_handle_t h_asyncio)
-{
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *) h_asyncio;
+asyncio_tx_token_t asyncio_allocate_tx_token(asyncio_handle_t h_asyncio) {
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)h_asyncio;
   asyncio_tx_thread_context_t *pCtx = &p_asyncio->tx_task;
   asyncio_tx_request_t *pReq = 0;
 
-  if(atomic_load(&pCtx->init_state) == AsyncioInitialized) {
-    pReq = (asyncio_tx_request_t *) pool_alloc(pCtx->buffer_pool);
+  if (atomic_load(&pCtx->init_state) == AsyncioInitialized) {
+    pReq = (asyncio_tx_request_t *)pool_alloc(pCtx->buffer_pool);
     if (pReq) {
       pReq->fn = 0;
       pReq->p_private = 0;
@@ -192,12 +202,11 @@ asyncio_tx_token_t asyncio_allocate_tx_token(asyncio_handle_t h_asyncio)
       pReq->buffer_offset = p_asyncio->tx_task.tx_buffer_offset;
     }
   }
-  return (asyncio_tx_token_t) pReq;
+  return (asyncio_tx_token_t)pReq;
 }
 
-void asyncio_release_tx_token(asyncio_handle_t h_asyncio, asyncio_tx_token_t token)
-{
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *) h_asyncio;
+void asyncio_release_tx_token(asyncio_handle_t h_asyncio, asyncio_tx_token_t token) {
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)h_asyncio;
   asyncio_tx_thread_context_t *p_ctx = &p_asyncio->tx_task;
 
   if (p_asyncio && token && atomic_load(&p_ctx->init_state) == AsyncioInitialized) {
@@ -205,18 +214,16 @@ void asyncio_release_tx_token(asyncio_handle_t h_asyncio, asyncio_tx_token_t tok
   }
 }
 
-static inline uint8_t *asyncio_tx_request_get_buffer(asyncio_tx_request_t *p_req)
-{
+static inline uint8_t *asyncio_tx_request_get_buffer(asyncio_tx_request_t *p_req) {
   uint8_t *retval = 0;
 
-  retval = ((uint8_t *) p_req) + p_req->buffer_offset;
+  retval = ((uint8_t *)p_req) + p_req->buffer_offset;
   return retval;
 }
 
-uint8_t *asyncio_tx_token_get_data_buffer(asyncio_tx_token_t token)
-{
+uint8_t *asyncio_tx_token_get_data_buffer(asyncio_tx_token_t token) {
   uint8_t *retval = 0;
-  asyncio_tx_request_t *p_req = (asyncio_tx_request_t *) token;
+  asyncio_tx_request_t *p_req = (asyncio_tx_request_t *)token;
 
   if (p_req) {
     retval = asyncio_tx_request_get_buffer(p_req);
@@ -224,9 +231,8 @@ uint8_t *asyncio_tx_token_get_data_buffer(asyncio_tx_token_t token)
   return retval;
 }
 
-uint32_t asyncio_tx_token_get_max_data_size(asyncio_handle_t h_asyncio)
-{
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *) h_asyncio;
+uint32_t asyncio_tx_token_get_max_data_size(asyncio_handle_t h_asyncio) {
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)h_asyncio;
 
   return p_asyncio->tx_task.max_tx_data_chunk_size;
 }
@@ -235,16 +241,14 @@ bool asyncio_send_buffer(asyncio_handle_t h_asyncio,
                          asyncio_tx_token_t token,
                          uint32_t size,
                          asyncio_tx_notification_f fn,
-                         void *p_private)
-{
+                         void *p_private) {
   bool retval = false;
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *) h_asyncio;
-  asyncio_tx_request_t *p_req = (asyncio_tx_request_t *) token;
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)h_asyncio;
+  asyncio_tx_request_t *p_req = (asyncio_tx_request_t *)token;
 
-  if (p_asyncio &&
-      !p_asyncio->stream_stopped &&
-      atomic_load(&p_asyncio->tx_task.init_state) == AsyncioInitialized &&
-      p_req && size > 0 && size < p_asyncio->tx_task.max_tx_data_chunk_size) {
+  if (p_asyncio && !p_asyncio->stream_stopped &&
+      atomic_load(&p_asyncio->tx_task.init_state) == AsyncioInitialized && p_req && size > 0 &&
+      size < p_asyncio->tx_task.max_tx_data_chunk_size) {
     p_req->size = size;
     p_req->fn = fn;
     p_req->p_private = p_private;
@@ -253,9 +257,8 @@ bool asyncio_send_buffer(asyncio_handle_t h_asyncio,
   return retval;
 }
 
-void asyncio_release_rx_buffer(asyncio_handle_t h_asyncio, asyncio_message_t message)
-{
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *) h_asyncio;
+void asyncio_release_rx_buffer(asyncio_handle_t h_asyncio, asyncio_message_t message) {
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)h_asyncio;
 
   if (p_asyncio && message) {
     pool_free(p_asyncio->rx_task.buffer_pool, message);
@@ -263,11 +266,11 @@ void asyncio_release_rx_buffer(asyncio_handle_t h_asyncio, asyncio_message_t mes
 }
 
 static void asyncio_configure_tx_thread(asyncio_create_params_t *p_params,
-                                        asyncio_interface_instance_t *p_asyncio)
-{
+                                        asyncio_interface_instance_t *p_asyncio) {
   asyncio_tx_thread_context_t *pCtx = &p_asyncio->tx_task;
 
-  CUTILS_ASSERTF(atomic_load(&pCtx->init_state) == AsyncioUninitialized, "Tx Thread should be uninitialized");
+  CUTILS_ASSERTF(atomic_load(&pCtx->init_state) == AsyncioUninitialized,
+                 "Tx Thread should be uninitialized");
   strncpy(pCtx->thread_name, p_params->stream_name, ASYNCIO_MAX_THREAD_NAME - 3);
   strcat(pCtx->thread_name, "Tx");
   pCtx->max_tx_data_chunk_size = p_params->tx_max_chunk_size;
@@ -278,11 +281,11 @@ static void asyncio_configure_tx_thread(asyncio_create_params_t *p_params,
 }
 
 static void asyncio_configure_rx_thread(asyncio_create_params_t *p_params,
-                                        asyncio_interface_instance_t *p_asyncio)
-{
+                                        asyncio_interface_instance_t *p_asyncio) {
   asyncio_rx_thread_context_t *p_ctx = &p_asyncio->rx_task;
 
-  CUTILS_ASSERTF(atomic_load(&p_ctx->init_state) == AsyncioUninitialized, "Rx Thread should be uninitialized");
+  CUTILS_ASSERTF(atomic_load(&p_ctx->init_state) == AsyncioUninitialized,
+                 "Rx Thread should be uninitialized");
   strncpy(p_ctx->thread_name, p_params->stream_name, ASYNCIO_MAX_THREAD_NAME - 3);
   strcat(p_ctx->thread_name, "Rx");
   p_ctx->worker = p_params->rx_worker;
@@ -291,8 +294,7 @@ static void asyncio_configure_rx_thread(asyncio_create_params_t *p_params,
   p_ctx->client_data = p_params->client_data;
 }
 
-static inline void trigger_start_completion(asyncio_interface_instance_t *p_asyncio)
-{
+static inline void trigger_start_completion(asyncio_interface_instance_t *p_asyncio) {
   asyncio_rx_thread_context_t *p_rx_ctx = &p_asyncio->rx_task;
   asyncio_tx_thread_context_t *p_tx_ctx = &p_asyncio->tx_task;
 
@@ -303,14 +305,13 @@ static inline void trigger_start_completion(asyncio_interface_instance_t *p_asyn
   }
 }
 
-static void starter_f(void* arg1, void* arg2)
-{
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t*)arg1;
+static void starter_f(void *arg1, void *arg2) {
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)arg1;
   bool is_rx = ((size_t)arg2 == 0) ? true : false;
   asyncio_tx_thread_context_t *p_tx_ctx = &p_asyncio->tx_task;
   asyncio_rx_thread_context_t *p_rx_ctx = &p_asyncio->rx_task;
 
-  if(is_rx) {
+  if (is_rx) {
     p_rx_ctx->buffer_pool = pool_create(&p_rx_ctx->rx_pool_params);
     CUTILS_ASSERTF(p_rx_ctx->buffer_pool, "Failed to allocate Rx Buffer Pool");
     atomic_store(&p_rx_ctx->init_state, AsyncioInitialized);
@@ -318,9 +319,9 @@ static void starter_f(void* arg1, void* arg2)
     dispatch_async_f(p_rx_ctx->worker, rx_f, p_asyncio, 0);
   } else {
     STREAM_CLOGV("Tx Pool = %lu, %lu, %lu",
-        p_tx_ctx->pool_create_params.num_of_elements,
-        p_tx_ctx->pool_create_params.element_size_requested,
-        p_tx_ctx->pool_create_params.total_element_size)
+                 p_tx_ctx->pool_create_params.num_of_elements,
+                 p_tx_ctx->pool_create_params.element_size_requested,
+                 p_tx_ctx->pool_create_params.total_element_size)
     p_tx_ctx->buffer_pool = pool_create(&p_tx_ctx->pool_create_params);
     CUTILS_ASSERTF(p_tx_ctx->buffer_pool, "Failed to allocate Tx Buffer Pool");
     atomic_store(&p_tx_ctx->init_state, AsyncioInitialized);
@@ -329,27 +330,25 @@ static void starter_f(void* arg1, void* arg2)
   trigger_start_completion(p_asyncio);
 }
 
-static bool asyncio_start_tx_thread(asyncio_interface_instance_t *p_asyncio)
-{
+static bool asyncio_start_tx_thread(asyncio_interface_instance_t *p_asyncio) {
   asyncio_tx_thread_context_t *p_ctx = &p_asyncio->tx_task;
   atomic_store(&p_ctx->init_state, AsyncioInitializing);
-  dispatch_async_f(p_ctx->worker, starter_f, p_asyncio, (void*)1);
+  dispatch_async_f(p_ctx->worker, starter_f, p_asyncio, (void *)1);
   return true;
 }
 
-static bool asyncio_start_rx_thread(asyncio_interface_instance_t *p_asyncio)
-{
+static bool asyncio_start_rx_thread(asyncio_interface_instance_t *p_asyncio) {
   asyncio_rx_thread_context_t *p_ctx = &p_asyncio->rx_task;
 
   CUTILS_ASSERTF(p_ctx->worker, "Worker Must Be provided");
-  CUTILS_ASSERTF(p_ctx->rx_callback, "An RxCallback that handles read out messages must be provided");
+  CUTILS_ASSERTF(p_ctx->rx_callback,
+                 "An RxCallback that handles read out messages must be provided");
   atomic_store(&p_ctx->init_state, AsyncioInitializing);
   dispatch_async_f(p_ctx->worker, starter_f, p_asyncio, 0);
   return true;
 }
 
-static inline void trigger_stop_completion(asyncio_interface_instance_t *p_asyncio)
-{
+static inline void trigger_stop_completion(asyncio_interface_instance_t *p_asyncio) {
   asyncio_rx_thread_context_t *p_rx_ctx = &p_asyncio->rx_task;
   asyncio_tx_thread_context_t *p_tx_ctx = &p_asyncio->tx_task;
   if (atomic_load(&p_rx_ctx->init_state) == AsyncioUninitialized &&
@@ -359,13 +358,12 @@ static inline void trigger_stop_completion(asyncio_interface_instance_t *p_async
   }
 }
 
-static void finisher_f(void *arg1, void *arg2)
-{
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t*)arg1;
+static void finisher_f(void *arg1, void *arg2) {
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)arg1;
   asyncio_rx_thread_context_t *p_rx_ctx = &p_asyncio->rx_task;
   asyncio_tx_thread_context_t *p_tx_ctx = &p_asyncio->tx_task;
   int expected = AsyncioUninitializing;
-  if( (size_t)arg2 == 0) {
+  if ((size_t)arg2 == 0) {
     if (atomic_compare_exchange_strong(&p_rx_ctx->init_state, &expected, AsyncioUninitialized)) {
       pool_destroy(p_rx_ctx->buffer_pool);
       STREAM_SLOG("Stopped Rx");
@@ -379,35 +377,38 @@ static void finisher_f(void *arg1, void *arg2)
   trigger_stop_completion(p_asyncio);
 }
 
-static void asyncio_stop_rx_thread(asyncio_interface_instance_t *p_asyncio)
-{
+static void asyncio_stop_rx_thread(asyncio_interface_instance_t *p_asyncio) {
   asyncio_rx_thread_context_t *p_ctx = &p_asyncio->rx_task;
   int expected = AsyncioInitialized;
-  //TODO: Make sure no more task are being pushed to the dispatch_queue
-  if (atomic_compare_exchange_strong(&p_ctx->init_state, &expected, AsyncioUninitializing) ){
+  // TODO: Make sure no more task are being pushed to the dispatch_queue
+  if (atomic_compare_exchange_strong(&p_ctx->init_state, &expected, AsyncioUninitializing)) {
     dispatch_async_f(p_ctx->worker, finisher_f, p_asyncio, 0);
   } else {
-    STREAM_SLOG("No Stop Rx Thread - %s", get_asyncio_init_state_e_string(atomic_load(&p_ctx->init_state)));
+    STREAM_SLOG("No Stop Rx Thread - %s",
+                get_asyncio_init_state_e_string(atomic_load(&p_ctx->init_state)));
   }
-  CUTILS_ASSERTF(expected != AsyncioInitializing, "Unexpected state %s", get_asyncio_init_state_e_string(expected));
+  CUTILS_ASSERTF(expected != AsyncioInitializing,
+                 "Unexpected state %s",
+                 get_asyncio_init_state_e_string(expected));
 }
 
-static void asyncio_stop_tx_thread(asyncio_interface_instance_t *p_asyncio)
-{
+static void asyncio_stop_tx_thread(asyncio_interface_instance_t *p_asyncio) {
   asyncio_tx_thread_context_t *p_ctx = &p_asyncio->tx_task;
   int expected = AsyncioInitialized;
-  if(atomic_compare_exchange_strong(&p_ctx->init_state, &expected, AsyncioUninitializing)) {
-    dispatch_async_f(p_ctx->worker, finisher_f, p_asyncio, (void*)1);
+  if (atomic_compare_exchange_strong(&p_ctx->init_state, &expected, AsyncioUninitializing)) {
+    dispatch_async_f(p_ctx->worker, finisher_f, p_asyncio, (void *)1);
   } else {
-    STREAM_SLOG("No Stop Tx Thread - %s", get_asyncio_init_state_e_string(atomic_load(&p_ctx->init_state)));
+    STREAM_SLOG("No Stop Tx Thread - %s",
+                get_asyncio_init_state_e_string(atomic_load(&p_ctx->init_state)));
   }
-  CUTILS_ASSERTF(expected != AsyncioInitializing, "Unexpected state %s", get_asyncio_init_state_e_string(expected));
+  CUTILS_ASSERTF(expected != AsyncioInitializing,
+                 "Unexpected state %s",
+                 get_asyncio_init_state_e_string(expected));
 }
 
-static void tx_f(void *arg1, void *arg2)
-{
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *) arg1;
-  asyncio_tx_request_t *p_req = (asyncio_tx_request_t *) arg2;
+static void tx_f(void *arg1, void *arg2) {
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)arg1;
+  asyncio_tx_request_t *p_req = (asyncio_tx_request_t *)arg2;
   uint32_t timeout = p_asyncio->tx_task.tx_write_timeout;
   size_t bytes_written = 0;
   asyncio_tx_send_status_e status = StreamTxSendSuccess;
@@ -415,14 +416,12 @@ static void tx_f(void *arg1, void *arg2)
 
   if (atomic_load(&p_asyncio->init_state) == AsyncioInitialized) {
     if (!p_asyncio->is_in_error) {
-      STREAM_CLOGV("Sending Data, Buf = %p",
-                   asyncio_tx_request_get_buffer(p_req));
-      bytes_written = p_asyncio->f_stream_interface_write(p_asyncio,
-                                                          p_req->size,
-                                                          asyncio_tx_request_get_buffer(p_req),
-                                                          timeout);
+      STREAM_CLOGV("Sending Data, Buf = %p", asyncio_tx_request_get_buffer(p_req));
+      bytes_written = p_asyncio->f_stream_interface_write(
+          p_asyncio, p_req->size, asyncio_tx_request_get_buffer(p_req), timeout);
       if (bytes_written != p_req->size) {
-        STREAM_SLOG("%s(): bytes Written %u != req Size %u", __FUNCTION__, bytes_written, p_req->size);
+        STREAM_SLOG(
+            "%s(): bytes Written %u != req Size %u", __FUNCTION__, bytes_written, p_req->size);
         status = StreamTxSendMessageFail;
       }
     } else {
@@ -431,17 +430,16 @@ static void tx_f(void *arg1, void *arg2)
     }
 
     if (p_req->fn) {
-      p_req->fn((asyncio_tx_token_t) p_req, status, bytes_written, p_req->p_private);
+      p_req->fn((asyncio_tx_token_t)p_req, status, bytes_written, p_req->p_private);
     }
   }
   pool_free(p_asyncio->tx_task.buffer_pool, p_req);
 }
 
-static void rx_f(void* arg1, void* arg2)
-{
+static void rx_f(void *arg1, void *arg2) {
   uint8_t *p_buf = 0;
   size_t bytes_read = 0;
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *) arg1;
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)arg1;
   asyncio_rx_thread_context_t *p_rx_ctx = &p_asyncio->rx_task;
 
   if (atomic_load(&p_rx_ctx->init_state) == AsyncioInitialized) {
@@ -464,10 +462,9 @@ static void rx_f(void* arg1, void* arg2)
   }
 }
 
-void *asyncio_get_private_data(asyncio_handle_t h_asyncio)
-{
+void *asyncio_get_private_data(asyncio_handle_t h_asyncio) {
   void *retval = 0;
-  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *) h_asyncio;
+  asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)h_asyncio;
 
   if (p_asyncio) {
     retval = p_asyncio->rx_task.client_data;

--- a/src/bst.c
+++ b/src/bst.c
@@ -25,9 +25,7 @@
 #include <cutils/bst.h>
 #include <cutils/logger.h>
 
-
-void bst_insert(bst_t *bst, KListElem *elem)
-{
+void bst_insert(bst_t *bst, KListElem *elem) {
   CUTILS_ASSERTF(bst, "Invalid BST");
   elem->prev = elem->next = 0;
   if (!bst->root) {
@@ -51,8 +49,7 @@ void bst_insert(bst_t *bst, KListElem *elem)
   }
 }
 
-KListElem *bst_search_inner(KListElem *root, KListElem *key, bst_less_f less)
-{
+KListElem *bst_search_inner(KListElem *root, KListElem *key, bst_less_f less) {
   if (!root || !less(key, root)) {
     return root;
   } else if (less(key, root) < 0) {
@@ -62,14 +59,12 @@ KListElem *bst_search_inner(KListElem *root, KListElem *key, bst_less_f less)
   }
 }
 
-KListElem *bst_search(bst_t *bst, KListElem *key)
-{
+KListElem *bst_search(bst_t *bst, KListElem *key) {
   CUTILS_ASSERTF(bst, "Invalid BST");
   return bst_search_inner(bst->root, key, bst->f_less);
 }
 
-static void bst_traverse_inner(KListElem *root, bst_traverse_f fn, va_list args)
-{
+static void bst_traverse_inner(KListElem *root, bst_traverse_f fn, va_list args) {
   if (root) {
     bst_traverse_inner(root->prev, fn, args);
     fn(root, args);
@@ -77,8 +72,7 @@ static void bst_traverse_inner(KListElem *root, bst_traverse_f fn, va_list args)
   }
 }
 
-void bst_traverse(bst_t *bst, bst_traverse_f fn, ...)
-{
+void bst_traverse(bst_t *bst, bst_traverse_f fn, ...) {
   va_list args;
   va_start(args, fn);
   bst_traverse_inner(bst->root, fn, args);

--- a/src/c11/CMakeLists.txt
+++ b/src/c11/CMakeLists.txt
@@ -1,14 +1,13 @@
 project(platform_abstraction C)
 find_package(Threads REQUIRED)
 
-file(GLOB PLATFORM_HEADER_LIST CONFIGURE_DEPENDS "${cutils_SOURCE_DIR}/inc/cutils/c11/*.h" )
+file(GLOB PLATFORM_HEADER_LIST CONFIGURE_DEPENDS "${cutils_SOURCE_DIR}/inc/cutils/c11/*.h")
 
-set( PLATFORM_SOURCES task.c event_flag.c )
-add_library(platform_abstraction STATIC "${PLATFORM_HEADER_LIST}" "${HEADER_LIST}" "${PLATFORM_SOURCES}" )
+set(PLATFORM_SOURCES task.c event_flag.c)
+add_library(platform_abstraction STATIC "${PLATFORM_HEADER_LIST}" "${HEADER_LIST}"
+                                        "${PLATFORM_SOURCES}")
 set_target_properties(platform_abstraction PROPERTIES LINKER_LANGUAGE C)
 target_compile_features(platform_abstraction PUBLIC c_std_11)
 target_compile_definitions(platform_abstraction PUBLIC -DUSE_STD_PRINTF)
 target_link_libraries(platform_abstraction ${CMAKE_THREAD_LIBS_INIT} logger_basic)
 target_include_directories(platform_abstraction PUBLIC ${API_INCLUDES})
-
-

--- a/src/c11/event_flag.c
+++ b/src/c11/event_flag.c
@@ -24,37 +24,35 @@
 
 #include <cutils/event_flag.h>
 
-
-bool event_flag_new(event_flag_t *p_flags)
-{
+bool event_flag_new(event_flag_t *p_flags) {
   bool retval = false;
-  if (p_flags &&
-      !pthread_mutex_init(&p_flags->mtx, 0) &&
-      !pthread_cond_init(&p_flags->cv, 0)){
+  if (p_flags && !pthread_mutex_init(&p_flags->mtx, 0) && !pthread_cond_init(&p_flags->cv, 0)) {
     p_flags->val = 0;
     retval = true;
   }
   return retval;
 }
 
-bool event_flag_free(event_flag_t *p_flags)
-{
-  return (p_flags && !pthread_cond_destroy(&p_flags->cv) && !pthread_mutex_destroy(&p_flags->mtx) );
+bool event_flag_free(event_flag_t *p_flags) {
+  return (p_flags && !pthread_cond_destroy(&p_flags->cv) && !pthread_mutex_destroy(&p_flags->mtx));
 }
 
-static inline bool check_flags(event_flag_t *p_flags, uint32_t required_flags, event_flag_wait_type_e wait_type,
-                               uint32_t *p_actual_flags)
-{
+static inline bool check_flags(event_flag_t *p_flags,
+                               uint32_t required_flags,
+                               event_flag_wait_type_e wait_type,
+                               uint32_t *p_actual_flags) {
   bool retval = false;
   uint32_t act_flags = p_flags->val & required_flags;
   if (wait_type == WAIT_OR || wait_type == WAIT_OR_CLEAR) {
     if (act_flags) {
-      if (p_actual_flags) *p_actual_flags = act_flags;
+      if (p_actual_flags)
+        *p_actual_flags = act_flags;
       retval = true;
     }
   } else {
     if (act_flags == required_flags) {
-      if (p_actual_flags) *p_actual_flags = act_flags;
+      if (p_actual_flags)
+        *p_actual_flags = act_flags;
       retval = true;
     }
   }
@@ -64,9 +62,11 @@ static inline bool check_flags(event_flag_t *p_flags, uint32_t required_flags, e
   return retval;
 }
 
-bool event_flag_wait(event_flag_t *p_flags, uint32_t required_flags, event_flag_wait_type_e wait_type,
-                     uint32_t *p_actual_flags, uint32_t wait_ms)
-{
+bool event_flag_wait(event_flag_t *p_flags,
+                     uint32_t required_flags,
+                     event_flag_wait_type_e wait_type,
+                     uint32_t *p_actual_flags,
+                     uint32_t wait_ms) {
   bool retval = false;
   struct timespec ts = {0};
 
@@ -94,8 +94,8 @@ bool event_flag_wait(event_flag_t *p_flags, uint32_t required_flags, event_flag_
       }
       CHECK_RUN(!rval || (rval != ETIMEDOUT && rval != EINVAL && rval != EPERM),
                 pthread_mutex_unlock(&p_flags->mtx);
-                return retval;,
-                "Condition Variable wait failed due to error: %d", rval);
+                return retval;
+                , "Condition Variable wait failed due to error: %d", rval);
       if (rval) {
         break;
       }
@@ -106,10 +106,9 @@ bool event_flag_wait(event_flag_t *p_flags, uint32_t required_flags, event_flag_
   return retval;
 }
 
-bool event_flag_send(event_flag_t *p_flags, uint32_t flag_bits)
-{
+bool event_flag_send(event_flag_t *p_flags, uint32_t flag_bits) {
   bool retval = false;
-  if(p_flags) {
+  if (p_flags) {
     pthread_mutex_lock(&p_flags->mtx);
     p_flags->val |= flag_bits;
     pthread_cond_broadcast(&p_flags->cv);
@@ -119,10 +118,9 @@ bool event_flag_send(event_flag_t *p_flags, uint32_t flag_bits)
   return retval;
 }
 
-bool event_flag_clear(event_flag_t *p_flags, uint32_t flag_bits)
-{
+bool event_flag_clear(event_flag_t *p_flags, uint32_t flag_bits) {
   bool retval = false;
-  if(p_flags) {
+  if (p_flags) {
     pthread_mutex_lock(&p_flags->mtx);
     p_flags->val &= ~(flag_bits);
     pthread_mutex_unlock(&p_flags->mtx);

--- a/src/c11/task.c
+++ b/src/c11/task.c
@@ -22,68 +22,59 @@
  * THE SOFTWARE.
  */
 
-#include <cutils/task.h>
 #include <cutils/logger.h>
+#include <cutils/task.h>
 #include <string.h>
 
-static int thread_runner_f(void* ctx)
-{
-  task_t* p_task = (task_t*)ctx;
+static int thread_runner_f(void *ctx) {
+  task_t *p_task = (task_t *)ctx;
   p_task->func(p_task->ctx);
   return 0;
 }
 
-task_t *task_new_static(task_create_params_t *create_params)
-{
+task_t *task_new_static(task_create_params_t *create_params) {
   task_t *retval = 0;
 
-  if (create_params &&
-      create_params->task &&
-      create_params->func  && create_params->stack && create_params->stack_size) {
+  if (create_params && create_params->task && create_params->func && create_params->stack &&
+      create_params->stack_size) {
     memset(create_params->task, 0, sizeof(task_t));
     create_params->task->func = create_params->func;
     create_params->task->ctx = create_params->ctx;
     int r = thrd_create_ex(&create_params->task->task,
-                            thread_runner_f,
-                            create_params->task,
-                            create_params->label,
-                            create_params->priority,
-                            create_params->stack,
-                            create_params->stack_size);
+                           thread_runner_f,
+                           create_params->task,
+                           create_params->label,
+                           create_params->priority,
+                           create_params->stack,
+                           create_params->stack_size);
 
-    strncpy(create_params->task->label, create_params->label, sizeof(create_params->task->label) -1);
-    //TODO: Add an assertion
+    strncpy(
+        create_params->task->label, create_params->label, sizeof(create_params->task->label) - 1);
+    // TODO: Add an assertion
     retval = (r == 0) ? create_params->task : 0;
   }
   return retval;
 }
 
-void task_destroy_static(task_t *task)
-{
-  if(task) {
+void task_destroy_static(task_t *task) {
+  if (task) {
     int res = 0;
     thrd_join(task->task, &res);
   }
 }
-bool task_start(task_t *task)
-{
-  return true;
-}
+bool task_start(task_t *task) { return true; }
 
-uint64_t task_get_ticks(void)
-{
+uint64_t task_get_ticks(void) {
   struct timespec res = {0};
   clock_gettime(CLOCK_REALTIME, &res);
   return res.tv_sec * 1000000000 + res.tv_nsec;
 }
 
-void task_sleep(uint32_t ms)
-{
-  struct timespec duration = {.tv_sec = ms/1000, .tv_nsec = ( ms % 1000 ) * 1000000};
+void task_sleep(uint32_t ms) {
+  struct timespec duration = {.tv_sec = ms / 1000, .tv_nsec = (ms % 1000) * 1000000};
   thrd_sleep(&duration, 0);
 }
 
-void task_get_current_name(char* name, size_t string_len)
-{
+void task_get_current_name(char *name, size_t string_len) {
   pthread_getname_np(thrd_current(), name, string_len);
 }

--- a/src/dispatch_queue.c
+++ b/src/dispatch_queue.c
@@ -24,14 +24,13 @@
 
 #include <cutils/dispatch_queue.h>
 
-static void dispatch_queue_worker(void *ctx)
-{
-  dispatch_queue_t *p_queue = (dispatch_queue_t *) ctx;
+static void dispatch_queue_worker(void *ctx) {
+  dispatch_queue_t *p_queue = (dispatch_queue_t *)ctx;
   while (1) {
     dispatch_queue_post_data_t *p_data = 0;
-    CUTILS_ASSERT(ts_queue_dequeue(p_queue->queue, (void **) &p_data, WAIT_FOREVER));
-    if ((void *) p_data == (void *) p_queue) {
-      //Kill Request
+    CUTILS_ASSERT(ts_queue_dequeue(p_queue->queue, (void **)&p_data, WAIT_FOREVER));
+    if ((void *)p_data == (void *)p_queue) {
+      // Kill Request
       break;
     } else {
       p_data->fn(p_data->arg1, p_data->arg2);
@@ -41,13 +40,12 @@ static void dispatch_queue_worker(void *ctx)
   signal_send(&p_queue->signal);
 }
 
-dispatch_queue_t *dispatch_queue_create(dispatch_queue_create_params_t *params)
-{
+dispatch_queue_t *dispatch_queue_create(dispatch_queue_create_params_t *params) {
   dispatch_queue_t *retval = 0;
 
   CUTILS_ASSERTF(params, "Provide valid Create Params");
   CUTILS_ASSERTF(params->queue_params.size, "Require a non-zero queue size");
-  CUTILS_ASSERTF(params->p_queue,"Control block not provided");
+  CUTILS_ASSERTF(params->p_queue, "Control block not provided");
 
   memset(params->p_queue, 0, sizeof(dispatch_queue_t));
 
@@ -72,15 +70,15 @@ dispatch_queue_t *dispatch_queue_create(dispatch_queue_create_params_t *params)
   return retval;
 }
 
-void dispatch_queue_destroy(dispatch_queue_t *p_queue)
-{
+void dispatch_queue_destroy(dispatch_queue_t *p_queue) {
   if (p_queue && !atomic_flag_test_and_set(&p_queue->destroying)) {
-    //We use a pointer value that is unacceptable to indicate that we want to kill the thread.
-    //The thread worker function will check items popped off the queue and if this pointer value is encountered
-    //It will exit the thread
-    dispatch_queue_post_data_t *p_data = (dispatch_queue_post_data_t *) p_queue;
-    CUTILS_ASSERTF(ts_queue_enqueue(p_queue->queue, p_data, NO_SLEEP), "Unable to queue Kill request");
-    //Wait for thread to exit
+    // We use a pointer value that is unacceptable to indicate that we want to kill the thread.
+    // The thread worker function will check items popped off the queue and if this pointer value is
+    // encountered It will exit the thread
+    dispatch_queue_post_data_t *p_data = (dispatch_queue_post_data_t *)p_queue;
+    CUTILS_ASSERTF(ts_queue_enqueue(p_queue->queue, p_data, NO_SLEEP),
+                   "Unable to queue Kill request");
+    // Wait for thread to exit
     if (signal_wait(&p_queue->signal)) {
       task_destroy_static(p_queue->p_task);
       p_queue->p_task = 0;

--- a/src/endian.c
+++ b/src/endian.c
@@ -24,30 +24,22 @@
 
 #include <cutils/endian.h>
 
+uint16_t byteswap16(uint16_t x) { return (uint16_t)(x << 8 | x >> 8); }
 
-uint16_t byteswap16(uint16_t x)
-{
-  return (uint16_t) (x << 8 | x >> 8);
-}
-
-uint32_t byteswap32(uint32_t x)
-{
+uint32_t byteswap32(uint32_t x) {
   return (((x ^ (x >> 16 | (x << 16))) & 0xFF00FFFF) >> 8) ^ (x >> 8 | x << 24);
 }
 
-uint64_t byteswap64(uint64_t x)
-{
-  union
-  {
+uint64_t byteswap64(uint64_t x) {
+  union {
     uint64_t ull;
     uint32_t ul[2];
   } u;
 
   /* This actually generates the best code */
-  u.ul[0] = (uint32_t) (x >> 32);
-  u.ul[1] = (uint32_t) (x & 0xffffffff);
+  u.ul[0] = (uint32_t)(x >> 32);
+  u.ul[1] = (uint32_t)(x & 0xffffffff);
   u.ul[0] = byteswap32(u.ul[0]);
   u.ul[1] = byteswap32(u.ul[1]);
   return u.ull;
 }
-

--- a/src/log_buffer.c
+++ b/src/log_buffer.c
@@ -26,8 +26,7 @@
 
 static void log_buffer_char_push(log_buffer_t *pLb, char item);
 
-static bool log_buffer_filter_character(log_buffer_t *pLb, char character)
-{
+static bool log_buffer_filter_character(log_buffer_t *pLb, char character) {
   bool retval = true;
 
   // filter ansi escape sequences by looking for escape
@@ -50,8 +49,7 @@ static bool log_buffer_filter_character(log_buffer_t *pLb, char character)
   return retval;
 }
 
-bool log_buffer_init(log_buffer_t *pLb, char *pBuffer, uint32_t bufferSize)
-{
+bool log_buffer_init(log_buffer_t *pLb, char *pBuffer, uint32_t bufferSize) {
   bool retval = false;
 
   if (pLb && pBuffer && bufferSize) {
@@ -64,8 +62,7 @@ bool log_buffer_init(log_buffer_t *pLb, char *pBuffer, uint32_t bufferSize)
   return retval;
 }
 
-bool log_buffer_push(log_buffer_t *pLb, char *pString, uint32_t stringSize)
-{
+bool log_buffer_push(log_buffer_t *pLb, char *pString, uint32_t stringSize) {
   bool retval = false;
 
   if (pLb && pLb->isInit && pString && stringSize < pLb->bufferSize) {
@@ -81,8 +78,7 @@ bool log_buffer_push(log_buffer_t *pLb, char *pString, uint32_t stringSize)
   return retval;
 }
 
-bool log_buffer_char_pop(log_buffer_t *pLb, int8_t *pChar)
-{
+bool log_buffer_char_pop(log_buffer_t *pLb, int8_t *pChar) {
   bool retval = false;
 
   if (pLb && pChar && pLb->head != pLb->tail) {
@@ -93,8 +89,7 @@ bool log_buffer_char_pop(log_buffer_t *pLb, int8_t *pChar)
   return retval;
 }
 
-bool log_buffer_is_empty(log_buffer_t *pLb)
-{
+bool log_buffer_is_empty(log_buffer_t *pLb) {
   bool retval = false;
 
   if (pLb && pLb->isInit) {
@@ -103,8 +98,7 @@ bool log_buffer_is_empty(log_buffer_t *pLb)
   return retval;
 }
 
-static void log_buffer_char_push(log_buffer_t *pLb, char item)
-{
+static void log_buffer_char_push(log_buffer_t *pLb, char item) {
   if (pLb && item) {
     pLb->p_buffer[pLb->head] = item;
     pLb->head = ((pLb->head + 1) < pLb->bufferSize) ? (pLb->head + 1) : 0;
@@ -115,18 +109,14 @@ static void log_buffer_char_push(log_buffer_t *pLb, char item)
   }
 }
 
-void log_buffer_clear(log_buffer_t *pLb)
-{
+void log_buffer_clear(log_buffer_t *pLb) {
   if (pLb && pLb->isInit) {
     pLb->head = pLb->tail = 0;
   }
 }
 
-
-uint32_t log_buffer_current_size(log_buffer_t *pLb,
-                                 uint32_t *initial_chunk,
-                                 uint32_t *residue_bytes)
-{
+uint32_t
+log_buffer_current_size(log_buffer_t *pLb, uint32_t *initial_chunk, uint32_t *residue_bytes) {
   uint32_t ibytes = 0;
   uint32_t rbytes = 0;
 
@@ -144,7 +134,6 @@ uint32_t log_buffer_current_size(log_buffer_t *pLb,
   return (ibytes + rbytes);
 }
 
-uint32_t log_buffer_lines_from_size(uint32_t size)
-{
-  return  1 + ((size - 1) / LOG_MAX_LINE_LENGTH);
+uint32_t log_buffer_lines_from_size(uint32_t size) {
+  return 1 + ((size - 1) / LOG_MAX_LINE_LENGTH);
 }

--- a/src/logger.c
+++ b/src/logger.c
@@ -23,31 +23,33 @@
  */
 
 #include <cutils/logger.h>
-#include <time.h>
-#include <string.h>
 #include <stdio.h>
+#include <string.h>
+#include <time.h>
 
-#define LOG_MAX_LINE_LENGTH                      (512)
+#define LOG_MAX_LINE_LENGTH (512)
 
 #ifdef USE_STD_PRINTF
-#define debugf     printf
+#define debugf printf
 #else
 #define debugf
 #endif
 
 SIMPLE_LOGGER_DEF(general_logger, "general", true);
 
-uint32_t logger_write_string(logger_t * p_logger,
+uint32_t logger_write_string(logger_t *p_logger,
                              void *p_private,
-                             const char *fmt, char *p_buffer, uint32_t buffer_size, va_list args)
-{
+                             const char *fmt,
+                             char *p_buffer,
+                             uint32_t buffer_size,
+                             va_list args) {
   size_t fmtLen = strlen(fmt);
   uint32_t index = 0;
 
   if (fmtLen < (buffer_size - 1) / 2) {
     if (p_logger->fnPrefix) {
-      index += p_logger->fnPrefix(p_logger,
-                                  p_private, p_buffer + index, buffer_size - index - (uint32_t) fmtLen);
+      index += p_logger->fnPrefix(
+          p_logger, p_private, p_buffer + index, buffer_size - index - (uint32_t)fmtLen);
       if (index < buffer_size - 2) {
         p_buffer[index++] = ':';
         p_buffer[index++] = ' ';
@@ -61,17 +63,16 @@ uint32_t logger_write_string(logger_t * p_logger,
   return index;
 }
 
-uint32_t SimpleLoggerPrefix(logger_t * p_logger, void *p_private, char *p_string, uint32_t string_size)
-{
+uint32_t
+SimpleLoggerPrefix(logger_t *p_logger, void *p_private, char *p_string, uint32_t string_size) {
   int size = 0;
-  simple_logger_t *p_simple = (simple_logger_t *) p_logger;
+  simple_logger_t *p_simple = (simple_logger_t *)p_logger;
 
   size = sprintf(p_string, "%s", p_simple->pPrefix);
-  return (size > 0) ? (uint32_t) size : 0;
+  return (size > 0) ? (uint32_t)size : 0;
 }
 
-void console_log(logger_t *logger, void *p_private, char *str, ...)
-{
+void console_log(logger_t *logger, void *p_private, char *str, ...) {
   char buf[LOG_MAX_LINE_LENGTH];
   va_list args;
 
@@ -82,22 +83,23 @@ void console_log(logger_t *logger, void *p_private, char *str, ...)
     time_t now = time(NULL);
     struct tm ts = *localtime(&now);
 
-    index = sprintf(buf, "[%04u/%02u/%02u-%02u:%02u:%02u]: ",
+    index = sprintf(buf,
+                    "[%04u/%02u/%02u-%02u:%02u:%02u]: ",
                     ts.tm_year,
                     ts.tm_mon,
                     ts.tm_mday,
                     ts.tm_hour,
                     ts.tm_min,
                     ts.tm_sec);
-    uint32_t bytes_written = logger_write_string(logger, p_private, str, buf + index, sizeof(buf) - index, args);
+    uint32_t bytes_written =
+        logger_write_string(logger, p_private, str, buf + index, sizeof(buf) - index, args);
     sprintf(buf + index + bytes_written, "\n");
     debugf(buf);
   }
   va_end(args);
 }
 
-void console_log_raw(char* str, ...)
-{
+void console_log_raw(char *str, ...) {
   va_list args;
   va_start(args, str);
   debugf(str, args);

--- a/src/notifier.c
+++ b/src/notifier.c
@@ -24,13 +24,12 @@
 
 #include <cutils/notifier.h>
 
+#define NOTIF_CLOG(str, ...)                                                                       \
+  console_log(&notifier->log.base, NULL, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+#define CLOGV(str, ...) CLOG_IF(notifier->log.base.log_level > 0, str, ##__VA_ARGS__)
+#define CLOGV_FIELD(x, f) LOG_FIELD(x, f, CLOGV)
 
-#define NOTIF_CLOG(str, ...)        console_log(&notifier->log.base, NULL, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
-#define CLOGV(str, ...)       CLOG_IF(notifier->log.base.log_level > 0, str, ##__VA_ARGS__)
-#define CLOGV_FIELD(x, f)     LOG_FIELD(x,f,CLOGV)
-
-bool notifier_init(notifier_create_params_t *params)
-{
+bool notifier_init(notifier_create_params_t *params) {
   bool retval = false;
 
   CUTILS_ASSERTF(params && params->notifier && params->notif_array, "Bad Inputs")
@@ -67,16 +66,14 @@ bool notifier_init(notifier_create_params_t *params)
   return retval;
 }
 
-void notifier_deinit(notifier_t *notifier)
-{
+void notifier_deinit(notifier_t *notifier) {
   CUTILS_ASSERT(notifier);
   pool_destroy(notifier->p_pool);
   notifier->p_pool = 0;
   mutex_free(&notifier->mtx);
 }
 
-notifier_block_t *notifier_allocate_notification_block(notifier_t *notifier)
-{
+notifier_block_t *notifier_allocate_notification_block(notifier_t *notifier) {
   notifier_block_t *retval = 0;
 
   CUTILS_ASSERT(notifier);
@@ -88,8 +85,9 @@ notifier_block_t *notifier_allocate_notification_block(notifier_t *notifier)
   return retval;
 }
 
-bool notifier_register_notification_block(notifier_t *notifier, uint32_t category, notifier_block_t *block)
-{
+bool notifier_register_notification_block(notifier_t *notifier,
+                                          uint32_t category,
+                                          notifier_block_t *block) {
   CUTILS_ASSERT(notifier && block && category < notifier->total_notification_categories);
   mutex_lock(&notifier->mtx, WAIT_FOREVER);
   block->category = category;
@@ -98,11 +96,10 @@ bool notifier_register_notification_block(notifier_t *notifier, uint32_t categor
   return true;
 }
 
-void notifier_deregister_notification_block(notifier_t *notifier, notifier_block_t *block)
-{
+void notifier_deregister_notification_block(notifier_t *notifier, notifier_block_t *block) {
   CUTILS_ASSERT(notifier && block && block->category < notifier->total_notification_categories)
   mutex_lock(&notifier->mtx, WAIT_FOREVER);
-  if (notifier->notif_array[block->category] == (KListHead *) block) {
+  if (notifier->notif_array[block->category] == (KListHead *)block) {
     notifier_block_t *pPopped;
 
     KLIST_HEAD_POP(notifier->notif_array[block->category], pPopped);
@@ -114,12 +111,11 @@ void notifier_deregister_notification_block(notifier_t *notifier, notifier_block
   mutex_unlock(&notifier->mtx);
 }
 
-static void Poster(KListElem *elem, ...)
-{
+static void Poster(KListElem *elem, ...) {
   va_list args;
   notifier_t *notifier = 0;
   void *pNotificationData = 0;
-  notifier_block_t *pBlock = (notifier_block_t *) elem;
+  notifier_block_t *pBlock = (notifier_block_t *)elem;
 
   va_start(args, elem);
   notifier = va_arg(args, notifier_t *);
@@ -132,10 +128,12 @@ static void Poster(KListElem *elem, ...)
   va_end(args);
 }
 
-void notifier_post_notification(notifier_t *notifier, uint32_t category, void *notification_data)
-{
-  CUTILS_ASSERTF(notifier && category < notifier->total_notification_categories, "Notifier: %p, category: %d, tot: %d",
-      notifier, category, notifier->total_notification_categories );
+void notifier_post_notification(notifier_t *notifier, uint32_t category, void *notification_data) {
+  CUTILS_ASSERTF(notifier && category < notifier->total_notification_categories,
+                 "Notifier: %p, category: %d, tot: %d",
+                 notifier,
+                 category,
+                 notifier->total_notification_categories);
   mutex_lock(&notifier->mtx, WAIT_FOREVER);
   KLIST_HEAD_FOREACH(notifier->notif_array[category], Poster, notifier, notification_data);
   mutex_unlock(&notifier->mtx);

--- a/src/pthread/CMakeLists.txt
+++ b/src/pthread/CMakeLists.txt
@@ -1,10 +1,11 @@
 project(platform_abstraction C)
 find_package(Threads REQUIRED)
 
-file(GLOB PLATFORM_HEADER_LIST CONFIGURE_DEPENDS "${cutils_SOURCE_DIR}/inc/cutils/pthread/*.h" )
+file(GLOB PLATFORM_HEADER_LIST CONFIGURE_DEPENDS "${cutils_SOURCE_DIR}/inc/cutils/pthread/*.h")
 
-set( PLATFORM_SOURCES task.c event_flag.c )
-add_library(platform_abstraction STATIC "${PLATFORM_HEADER_LIST}" "${HEADER_LIST}" "${PLATFORM_SOURCES}" )
+set(PLATFORM_SOURCES task.c event_flag.c)
+add_library(platform_abstraction STATIC "${PLATFORM_HEADER_LIST}" "${HEADER_LIST}"
+                                        "${PLATFORM_SOURCES}")
 set_target_properties(platform_abstraction PROPERTIES LINKER_LANGUAGE C)
 target_compile_features(platform_abstraction PUBLIC c_std_11)
 target_compile_definitions(platform_abstraction PUBLIC -DUSE_STD_PRINTF)

--- a/src/pthread/event_flag.c
+++ b/src/pthread/event_flag.c
@@ -26,36 +26,35 @@
 #include <cutils/logger.h>
 #include <errno.h>
 
-bool event_flag_new(event_flag_t *p_flags)
-{
+bool event_flag_new(event_flag_t *p_flags) {
   bool retval = false;
-  if (p_flags &&
-      !pthread_mutex_init(&p_flags->mtx, 0) &&
-      !pthread_cond_init(&p_flags->cv, 0)){
+  if (p_flags && !pthread_mutex_init(&p_flags->mtx, 0) && !pthread_cond_init(&p_flags->cv, 0)) {
     p_flags->val = 0;
     retval = true;
   }
   return retval;
 }
 
-bool event_flag_free(event_flag_t *p_flags)
-{
-  return (p_flags && !pthread_cond_destroy(&p_flags->cv) && !pthread_mutex_destroy(&p_flags->mtx) );
+bool event_flag_free(event_flag_t *p_flags) {
+  return (p_flags && !pthread_cond_destroy(&p_flags->cv) && !pthread_mutex_destroy(&p_flags->mtx));
 }
 
-static inline bool check_flags(event_flag_t *p_flags, uint32_t required_flags, event_flag_wait_type_e wait_type,
-                               uint32_t *p_actual_flags)
-{
+static inline bool check_flags(event_flag_t *p_flags,
+                               uint32_t required_flags,
+                               event_flag_wait_type_e wait_type,
+                               uint32_t *p_actual_flags) {
   bool retval = false;
   uint32_t act_flags = p_flags->val & required_flags;
   if (wait_type == WAIT_OR || wait_type == WAIT_OR_CLEAR) {
     if (act_flags) {
-      if (p_actual_flags) *p_actual_flags = act_flags;
+      if (p_actual_flags)
+        *p_actual_flags = act_flags;
       retval = true;
     }
   } else {
     if (act_flags == required_flags) {
-      if (p_actual_flags) *p_actual_flags = act_flags;
+      if (p_actual_flags)
+        *p_actual_flags = act_flags;
       retval = true;
     }
   }
@@ -65,9 +64,11 @@ static inline bool check_flags(event_flag_t *p_flags, uint32_t required_flags, e
   return retval;
 }
 
-bool event_flag_wait(event_flag_t *p_flags, uint32_t required_flags, event_flag_wait_type_e wait_type,
-                     uint32_t *p_actual_flags, uint32_t wait_ms)
-{
+bool event_flag_wait(event_flag_t *p_flags,
+                     uint32_t required_flags,
+                     event_flag_wait_type_e wait_type,
+                     uint32_t *p_actual_flags,
+                     uint32_t wait_ms) {
   bool retval = false;
   struct timespec ts = {0};
 
@@ -95,8 +96,8 @@ bool event_flag_wait(event_flag_t *p_flags, uint32_t required_flags, event_flag_
       }
       CHECK_RUN(!rval || (rval != ETIMEDOUT && rval != EINVAL && rval != EPERM),
                 pthread_mutex_unlock(&p_flags->mtx);
-                return retval;,
-                "Condition Variable wait failed due to error: %d", rval);
+                return retval;
+                , "Condition Variable wait failed due to error: %d", rval);
       if (rval) {
         break;
       }
@@ -107,10 +108,9 @@ bool event_flag_wait(event_flag_t *p_flags, uint32_t required_flags, event_flag_
   return retval;
 }
 
-bool event_flag_send(event_flag_t *p_flags, uint32_t flag_bits)
-{
+bool event_flag_send(event_flag_t *p_flags, uint32_t flag_bits) {
   bool retval = false;
-  if(p_flags) {
+  if (p_flags) {
     pthread_mutex_lock(&p_flags->mtx);
     p_flags->val |= flag_bits;
     pthread_cond_broadcast(&p_flags->cv);
@@ -120,10 +120,9 @@ bool event_flag_send(event_flag_t *p_flags, uint32_t flag_bits)
   return retval;
 }
 
-bool event_flag_clear(event_flag_t *p_flags, uint32_t flag_bits)
-{
+bool event_flag_clear(event_flag_t *p_flags, uint32_t flag_bits) {
   bool retval = false;
-  if(p_flags) {
+  if (p_flags) {
     pthread_mutex_lock(&p_flags->mtx);
     p_flags->val &= ~(flag_bits);
     pthread_mutex_unlock(&p_flags->mtx);

--- a/src/pthread/task.c
+++ b/src/pthread/task.c
@@ -9,10 +9,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,8 +22,8 @@
  * THE SOFTWARE.
  */
 
-#include <cutils/task.h>
 #include <cutils/logger.h>
+#include <cutils/task.h>
 #include <pthread.h>
 #include <string.h>
 
@@ -31,27 +31,21 @@
 static pthread_key_t s_task_private_key = 0;
 static pthread_once_t s_init = PTHREAD_ONCE_INIT;
 
-static void thread_init(void)
-{
-  pthread_key_create(&s_task_private_key, 0);
-}
+static void thread_init(void) { pthread_key_create(&s_task_private_key, 0); }
 
-static void* task_runner(void* ctx)
-{
-  task_t *task = (task_t*)ctx;
+static void *task_runner(void *ctx) {
+  task_t *task = (task_t *)ctx;
   pthread_once(&s_init, thread_init);
   pthread_setspecific(s_task_private_key, task);
   task->func(task->ctx);
   pthread_setspecific(s_task_private_key, NULL);
 }
 
-task_t *task_new_static(task_create_params_t *create_params)
-{
+task_t *task_new_static(task_create_params_t *create_params) {
   task_t *retval = 0;
 
-  if (create_params &&
-      create_params->task &&
-      create_params->func  && create_params->stack && create_params->stack_size) {
+  if (create_params && create_params->task && create_params->func && create_params->stack &&
+      create_params->stack_size) {
 
     pthread_attr_t attr = {0};
     size_t min_stack_size = 0;
@@ -60,64 +54,64 @@ task_t *task_new_static(task_create_params_t *create_params)
     pthread_attr_init(&attr);
 
     int rval = pthread_attr_getstacksize(&attr, &min_stack_size);
-    CHECK_RUN(!rval, pthread_attr_destroy(&attr); return retval, "Failed to query minimum stack size");
+    CHECK_RUN(!rval, pthread_attr_destroy(&attr);
+              return retval, "Failed to query minimum stack size");
     rval = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
-    CHECK_RUN(!rval, pthread_attr_destroy(&attr); return retval, "Failed to set scheduling parameter");
+    CHECK_RUN(!rval, pthread_attr_destroy(&attr);
+              return retval, "Failed to set scheduling parameter");
     rval = pthread_attr_setschedpolicy(&attr, SCHEDULING_POLICY);
     CHECK_RUN(!rval, pthread_attr_destroy(&attr); return retval, "Failed to set scheduling policy");
     struct sched_param param = {.sched_priority = create_params->priority};
     rval = pthread_attr_setschedparam(&attr, &param);
-    CHECK_RUN(!rval, pthread_attr_destroy(&attr); return retval, "Failed to set priority to %d", param.sched_priority);
-    if(create_params->stack && create_params->stack_size >= min_stack_size) {
+    CHECK_RUN(!rval, pthread_attr_destroy(&attr);
+              return retval, "Failed to set priority to %d", param.sched_priority);
+    if (create_params->stack && create_params->stack_size >= min_stack_size) {
       rval = pthread_attr_setstack(&attr, create_params->stack, create_params->stack_size);
-      CHECK_RUN(!rval, pthread_attr_destroy(&attr); return retval, "Failed to set stack", create_params->stack);
+      CHECK_RUN(!rval, pthread_attr_destroy(&attr);
+                return retval, "Failed to set stack", create_params->stack);
     }
-    CHECK_RUN(!rval, pthread_attr_destroy(&attr); return retval, "Failed to set scheduling priority between (%d, %d)",
-              sched_get_priority_min(SCHEDULING_POLICY), sched_get_priority_max(SCHEDULING_POLICY) );
+    CHECK_RUN(!rval, pthread_attr_destroy(&attr);
+              return retval,
+                     "Failed to set scheduling priority between (%d, %d)",
+                     sched_get_priority_min(SCHEDULING_POLICY),
+                     sched_get_priority_max(SCHEDULING_POLICY));
     create_params->task->ctx = create_params->ctx;
     create_params->task->func = create_params->func;
     int res = pthread_create(&create_params->task->task, &attr, task_runner, create_params->task);
     create_params->task->sanity = TASK_SANITY;
-    strncpy(create_params->task->label, create_params->label, sizeof(create_params->task->label) -1);
-    //TODO: Add an assertion
+    strncpy(
+        create_params->task->label, create_params->label, sizeof(create_params->task->label) - 1);
+    // TODO: Add an assertion
     retval = (res == 0) ? create_params->task : 0;
   }
   return retval;
 }
 
-void task_destroy_static(task_t *task)
-{
-  if(task) {
+void task_destroy_static(task_t *task) {
+  if (task) {
     int res = 0;
-    res = pthread_join(task->task, (void**)0);
-    CUTILS_ASSERTF( !res, "Thread Join Failed");
+    res = pthread_join(task->task, (void **)0);
+    CUTILS_ASSERTF(!res, "Thread Join Failed");
   }
 }
-bool task_start(task_t *task)
-{
-  return true;
-}
+bool task_start(task_t *task) { return true; }
 
-uint64_t task_get_ticks(void)
-{
+uint64_t task_get_ticks(void) {
   struct timespec res = {0};
   clock_gettime(CLOCK_REALTIME, &res);
   return res.tv_sec * 1000000000 + res.tv_nsec;
 }
 
-void task_sleep(uint32_t ms)
-{
-  struct timespec duration = {.tv_sec = ms/1000, .tv_nsec = ( ms % 1000 ) * 1000000};
+void task_sleep(uint32_t ms) {
+  struct timespec duration = {.tv_sec = ms / 1000, .tv_nsec = (ms % 1000) * 1000000};
   nanosleep(&duration, 0);
 }
 
-void task_get_current_name(char* name, size_t string_len)
-{
-  task_t* current = pthread_getspecific(s_task_private_key);
-  if(current && current->sanity == TASK_SANITY) {
+void task_get_current_name(char *name, size_t string_len) {
+  task_t *current = pthread_getspecific(s_task_private_key);
+  if (current && current->sanity == TASK_SANITY) {
     strncpy(name, current->label, string_len);
   } else {
     strncpy(name, "unknown", string_len);
   }
 }
-

--- a/src/ring_buffer.c
+++ b/src/ring_buffer.c
@@ -24,12 +24,11 @@
 
 #include "cutils/ring_buffer.h"
 
-#include <stdatomic.h>
 #include <assert.h>
+#include <stdatomic.h>
 #include <string.h>
 
-ring_buffer_ref create_ring_buffer(ring_buffer_create_params_t *params)
-{
+ring_buffer_ref create_ring_buffer(ring_buffer_create_params_t *params) {
   struct ring_buffer *buffer = params->buffer;
 
   if (!buffer) {
@@ -45,76 +44,63 @@ ring_buffer_ref create_ring_buffer(ring_buffer_create_params_t *params)
   return buffer;
 }
 
-void ring_buffer_release(ring_buffer_ref buffer)
-{
-  ring_buffer_reset_at_offset(buffer, 0);
-}
+void ring_buffer_release(ring_buffer_ref buffer) { ring_buffer_reset_at_offset(buffer, 0); }
 
-bool ring_buffer_is_empty(ring_buffer_ref buffer)
-{
+bool ring_buffer_is_empty(ring_buffer_ref buffer) {
   return ring_buffer_get_bytes_available_for_read(buffer) == 0;
 }
 
-bool ring_buffer_is_full(ring_buffer_ref buffer)
-{
+bool ring_buffer_is_full(ring_buffer_ref buffer) {
   return ring_buffer_get_bytes_available_for_write(buffer) == 0;
 }
 
-data_range_t ring_buffer_get_total_range(ring_buffer_ref buffer)
-{
+data_range_t ring_buffer_get_total_range(ring_buffer_ref buffer) {
   return make_data_range(buffer->read_offset, buffer->size);
 }
 
-data_range_t ring_buffer_get_current_data_range(ring_buffer_ref buffer)
-{
+data_range_t ring_buffer_get_current_data_range(ring_buffer_ref buffer) {
   return make_data_range(buffer->read_offset, ring_buffer_get_bytes_available_for_read(buffer));
 }
 
-uint32_t ring_buffer_get_bytes_available_for_read(ring_buffer_ref buffer)
-{
+uint32_t ring_buffer_get_bytes_available_for_read(ring_buffer_ref buffer) {
   /*
    This unsynchronized access is perfectly safe.
-   There's a race condition in that it's not certain whether the read thread will see the old or new value of _writeOffset.
-   However, it doesn't matter. _writeOffset can only increase, and the number of available bytes can likewise only increase.
-   If it sees the old value, it still computes a number of available bytes that's correct, just slightly out of date.
-   If it sees the new value, then so much the better. Therefore, the reader is safe.
+   There's a race condition in that it's not certain whether the read thread will see the old or new
+   value of _writeOffset. However, it doesn't matter. _writeOffset can only increase, and the number
+   of available bytes can likewise only increase. If it sees the old value, it still computes a
+   number of available bytes that's correct, just slightly out of date. If it sees the new value,
+   then so much the better. Therefore, the reader is safe.
    */
-  return (uint32_t) (buffer->write_offset - buffer->read_offset);
+  return (uint32_t)(buffer->write_offset - buffer->read_offset);
 }
 
-uint32_t ring_buffer_get_bytes_available_for_write(ring_buffer_ref buffer)
-{
+uint32_t ring_buffer_get_bytes_available_for_write(ring_buffer_ref buffer) {
   /*
-   it's safe for the reader thread to modify _readOffset while the writer is calculating bytesAvailableForRead.
-   Advancing the read pointer decreases the number of available bytes, which increases the amount of write space.
-   If the writer thread sees the old value for _readOffset here, it computes the older, smaller amount of write space, which is still safe, just slightly stale.
+   it's safe for the reader thread to modify _readOffset while the writer is calculating
+   bytesAvailableForRead. Advancing the read pointer decreases the number of available bytes, which
+   increases the amount of write space. If the writer thread sees the old value for _readOffset
+   here, it computes the older, smaller amount of write space, which is still safe, just slightly
+   stale.
    */
   return buffer->size - ring_buffer_get_bytes_available_for_read(buffer);
 }
 
-uint32_t ring_buffer_get_size(ring_buffer_ref buffer)
-{
-  return buffer->size;
-}
+uint32_t ring_buffer_get_size(ring_buffer_ref buffer) { return buffer->size; }
 
-void ring_buffer_reset_at_offset(ring_buffer_ref buffer, uint32_t offset)
-{
+void ring_buffer_reset_at_offset(ring_buffer_ref buffer, uint32_t offset) {
   buffer->read_offset = offset;
   buffer->write_offset = offset;
 }
 
-static inline uint32_t bufferReadOffsetWithOffset(ring_buffer_ref buffer, uint32_t offset)
-{
+static inline uint32_t bufferReadOffsetWithOffset(ring_buffer_ref buffer, uint32_t offset) {
   return (buffer->read_offset + offset) % buffer->size;
 }
 
-static inline uint32_t bufferWriteOffset(ring_buffer_ref buffer)
-{
+static inline uint32_t bufferWriteOffset(ring_buffer_ref buffer) {
   return buffer->write_offset % buffer->size;
 }
 
-uint32_t ring_buffer_write_data(ring_buffer_ref buffer, const uint8_t *data, const uint32_t size)
-{
+uint32_t ring_buffer_write_data(ring_buffer_ref buffer, const uint8_t *data, const uint32_t size) {
 
   if (ring_buffer_is_full(buffer) || size == 0) {
     return 0;
@@ -135,7 +121,6 @@ uint32_t ring_buffer_write_data(ring_buffer_ref buffer, const uint8_t *data, con
     // contiguous
     const uint32_t bytes_to_copy = bytes_to_write < size ? bytes_to_write : size;
     memcpy(buffer->data + file_write_offset, data, bytes_to_copy);
-
   }
 
   // cache range read so it can be forwarded
@@ -152,14 +137,14 @@ uint32_t ring_buffer_write_data(ring_buffer_ref buffer, const uint8_t *data, con
   return bytes_to_write;
 }
 
-ring_buffer_data_t ring_buffer_get_data_at_range(ring_buffer_ref buffer, data_range_t requested_range, bool peek)
-{
+ring_buffer_data_t
+ring_buffer_get_data_at_range(ring_buffer_ref buffer, data_range_t requested_range, bool peek) {
   const data_range_t current_range = ring_buffer_get_current_data_range(buffer);
 
   ring_buffer_data_t data = {0};
 
-  if (ring_buffer_is_empty(buffer)
-      || !location_in_data_range(requested_range.location, current_range)) {
+  if (ring_buffer_is_empty(buffer) ||
+      !location_in_data_range(requested_range.location, current_range)) {
     return data;
   }
 
@@ -209,42 +194,33 @@ ring_buffer_data_t ring_buffer_get_data_at_range(ring_buffer_ref buffer, data_ra
   return data;
 }
 
-ring_buffer_data_t ring_buffer_get_data(ring_buffer_ref buffer, uint32_t length, bool peek)
-{
+ring_buffer_data_t ring_buffer_get_data(ring_buffer_ref buffer, uint32_t length, bool peek) {
   const data_range_t read_range = make_data_range(buffer->read_offset, length);
   return ring_buffer_get_data_at_range(buffer, read_range, peek);
 }
 
-void ring_buffer_clear_data(ring_buffer_ref buffer, uint32_t length)
-{
+void ring_buffer_clear_data(ring_buffer_ref buffer, uint32_t length) {
   const data_range_t current_range = ring_buffer_get_current_data_range(buffer);
   const uint32_t bytes_to_clear = MIN(length, current_range.length);
   buffer->read_offset += bytes_to_clear;
 }
 
-void ring_buffer_set_callback_context(ring_buffer_ref buffer, void *ctx)
-{
-  buffer->ctx = ctx;
-}
+void ring_buffer_set_callback_context(ring_buffer_ref buffer, void *ctx) { buffer->ctx = ctx; }
 
-void *ring_buffer_get_callback_context(ring_buffer_ref buffer)
-{
-  return buffer->ctx;
-}
+void *ring_buffer_get_callback_context(ring_buffer_ref buffer) { return buffer->ctx; }
 
-void ring_buffer_set_on_read_callback(ring_buffer_ref buffer, data_changed_at_range_f callback)
-{
+void ring_buffer_set_on_read_callback(ring_buffer_ref buffer, data_changed_at_range_f callback) {
   buffer->on_data_read_at_range = callback;
 }
 
-void ring_buffer_set_on_write_callback(ring_buffer_ref buffer, data_changed_at_range_f callback)
-{
+void ring_buffer_set_on_write_callback(ring_buffer_ref buffer, data_changed_at_range_f callback) {
   buffer->on_data_written_at_range = callback;
 }
 
-void ring_buffer_get_offsets(ring_buffer_ref buffer, uint32_t *size,
-                             uint32_t *base_read_offset, uint32_t *write_offset)
-{
+void ring_buffer_get_offsets(ring_buffer_ref buffer,
+                             uint32_t *size,
+                             uint32_t *base_read_offset,
+                             uint32_t *write_offset) {
   *size = buffer->size;
   *base_read_offset = buffer->read_offset;
   *write_offset = buffer->write_offset;

--- a/src/state_event_loop.c
+++ b/src/state_event_loop.c
@@ -22,33 +22,37 @@
  * THE SOFTWARE.
  */
 
-#include <cutils/state_event_loop.h>
 #include <cutils/logger.h>
+#include <cutils/state_event_loop.h>
 
+#define SEL_CLOG(str, ...)                                                                         \
+  console_log(&event_loop->log, NULL, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
 
-#define SEL_CLOG(str, ...) console_log(&event_loop->log, NULL, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
-
-//TODO: Reenbale this
+// TODO: Reenbale this
 #define SEL_SLOG(str, ...)
-//system_log(&event_loop->log, NULL, "%s(%u):" str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+// system_log(&event_loop->log, NULL, "%s(%u):" str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
 #define EVENT_SLOG(p_event, str, ...)
-//system_log(&event_loop->log, p_event,  "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+// system_log(&event_loop->log, p_event,  "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
 
 #define CLOGV(str, ...) CLOG_IF(event_loop->log.log_level > 0, str, ##__VA_ARGS__)
 #define SLOGV(str, ...) SLOG_IF(event_loop->log.log_level > 0, str, ##__VA_ARGS__)
 #define DLOGV(str, ...) DLOG_IF(event_loop->log.log_level > 0, str, ##__VA_ARGS__)
 
-//Forward Declaration
-static uint32_t state_event_loop_logger_prefix(logger_t* logger, void* client_data, char* str, uint32_t string_size);
+// Forward Declaration
+static uint32_t state_event_loop_logger_prefix(logger_t *logger,
+                                               void *client_data,
+                                               char *str,
+                                               uint32_t string_size);
 
-state_event_loop_t *state_event_loop_init(state_event_loop_create_params_t * create_params)
-{
+state_event_loop_t *state_event_loop_init(state_event_loop_create_params_t *create_params) {
   dispatch_queue_create_params_t dispatch_create_params = create_params->queue_params;
 
   CUTILS_ASSERTF(create_params->p_event_loop, "Invalid Event Loop Pointer provided");
   CUTILS_ASSERTF(create_params->p_sm, "No State Machines provided");
-  CUTILS_ASSERTF(create_params->event_data_size > sizeof(event_t), "Invalid size (%lu) of event data, expected %lu",
-               create_params->event_data_size, sizeof(event_t));
+  CUTILS_ASSERTF(create_params->event_data_size > sizeof(event_t),
+                 "Invalid size (%lu) of event data, expected %lu",
+                 create_params->event_data_size,
+                 sizeof(event_t));
 
   state_event_loop_t *event_loop = create_params->p_event_loop;
 
@@ -59,36 +63,43 @@ state_event_loop_t *state_event_loop_init(state_event_loop_create_params_t * cre
   event_loop->name = create_params->name;
   event_loop->log.fnPrefix = state_event_loop_logger_prefix;
   event_loop->log.log_level = 0;
-  CUTILS_ASSERTF( event_loop->p_exec_queue, "Couldn't create exec queue");
+  CUTILS_ASSERTF(event_loop->p_exec_queue, "Couldn't create exec queue");
   if (event_loop->p_exec_queue) {
     // Create State Machine
     event_loop->num_machines = create_params->num_machines;
     event_loop->p_sm = create_params->p_sm;
-    for( uint32_t i = 0; i < event_loop->num_machines; i++) {
+    for (uint32_t i = 0; i < event_loop->num_machines; i++) {
       CLOGV("Will Create SM %s", create_params->p_sm_create_params[i].p_name);
       state_machine_create(&create_params->p_sm_create_params[i]);
     }
 
-    //Create Notifier that will be used to hold listeners of events posted.
-    CUTILS_ASSERTF(notifier_init(&create_params->notifier_create_params), "Could not initialize notifier");
+    // Create Notifier that will be used to hold listeners of events posted.
+    CUTILS_ASSERTF(notifier_init(&create_params->notifier_create_params),
+                   "Could not initialize notifier");
     event_loop->notifier = create_params->notifier_create_params.notifier;
 
     // Create Block pool of all events that will be used as posted data
     event_loop->p_pool_of_events = pool_create(&create_params->event_pool_create_params);
-    CUTILS_ASSERTF(event_loop->p_pool_of_events, "Couldn't create Block Pool for $s", create_params->name);
+    CUTILS_ASSERTF(
+        event_loop->p_pool_of_events, "Couldn't create Block Pool for $s", create_params->name);
 
     if ((event_loop->p_pool_of_events->element_size != create_params->event_data_size)) {
       SEL_CLOG("%s(): pool block size %u != event data size %u",
-           __FUNCTION__, event_loop->p_pool_of_events->element_size, create_params->event_data_size);
+               __FUNCTION__,
+               event_loop->p_pool_of_events->element_size,
+               create_params->event_data_size);
       pool_destroy(event_loop->p_pool_of_events);
       notifier_deinit(event_loop->notifier);
       event_loop->p_pool_of_events = 0;
       event_loop->notifier = 0;
       return NULL;
     }
-    if (event_loop->p_pool_of_events->num_of_elements != create_params->queue_params.queue_params.size) {
-      SEL_CLOG("%s(): blocks available %u != queue_size %u", __FUNCTION__,
-           event_loop->p_pool_of_events->num_of_elements, create_params->queue_params.queue_params.size);
+    if (event_loop->p_pool_of_events->num_of_elements !=
+        create_params->queue_params.queue_params.size) {
+      SEL_CLOG("%s(): blocks available %u != queue_size %u",
+               __FUNCTION__,
+               event_loop->p_pool_of_events->num_of_elements,
+               create_params->queue_params.queue_params.size);
       pool_destroy(event_loop->p_pool_of_events);
       notifier_deinit(event_loop->notifier);
       event_loop->p_pool_of_events = 0;
@@ -99,8 +110,7 @@ state_event_loop_t *state_event_loop_init(state_event_loop_create_params_t * cre
   return event_loop;
 }
 
-void state_event_loop_deinit(state_event_loop_t * event_loop)
-{
+void state_event_loop_deinit(state_event_loop_t *event_loop) {
   CUTILS_ASSERT(event_loop);
   SEL_SLOG("Destroying");
   dispatch_queue_destroy(event_loop->p_exec_queue);
@@ -111,27 +121,26 @@ void state_event_loop_deinit(state_event_loop_t * event_loop)
   SEL_SLOG("Destroyed");
 }
 
-void state_event_loop_add_state(state_event_loop_t * event_loop, state_t * state, uint32_t state_mac_id)
-{
+void state_event_loop_add_state(state_event_loop_t *event_loop,
+                                state_t *state,
+                                uint32_t state_mac_id) {
   if (event_loop) {
     state_machine_register_state(&event_loop->p_sm[state_mac_id], state);
   }
 }
 
-void state_event_loop_start(state_event_loop_t *event_loop)
-{
+void state_event_loop_start(state_event_loop_t *event_loop) {
   if (event_loop) {
-    for(uint32_t i = 0; i < event_loop->num_machines; i++) {
+    for (uint32_t i = 0; i < event_loop->num_machines; i++) {
       state_machine_start(&event_loop->p_sm[i]);
     }
   }
 }
 
-void state_event_loop_stop(state_event_loop_t * event_loop)
-{
+void state_event_loop_stop(state_event_loop_t *event_loop) {
   if (event_loop) {
-    for(uint32_t i = 0; i < event_loop->num_machines; i++) {
-     state_machine_stop(&event_loop->p_sm[i]);
+    for (uint32_t i = 0; i < event_loop->num_machines; i++) {
+      state_machine_stop(&event_loop->p_sm[i]);
     }
     // TODO: Other things maybe... like stop allowing notifications to post.
   }
@@ -139,25 +148,24 @@ void state_event_loop_stop(state_event_loop_t * event_loop)
 
 bool state_event_loop_install_event_pre_proc(state_event_loop_t *event_loop,
                                              void (*fn)(event_t *, void *),
-                                             void *client_data)
-{
+                                             void *client_data) {
   bool retval = false;
-  if(!event_loop->p_sm->state_machine_started) {
+  if (!event_loop->p_sm->state_machine_started) {
     event_loop->event_pre_proc_f = fn;
     event_loop->client_data = client_data;
   }
   return retval;
 }
 
-void state_event_loop_exec_queue_f(void *arg1, void *arg2)
-{
-  event_t *event = (event_t *) arg1;
+void state_event_loop_exec_queue_f(void *arg1, void *arg2) {
+  event_t *event = (event_t *)arg1;
   state_event_loop_t *event_loop = event->event_loop;
 
   // pass the event to the state machine
   uint32_t time_taken = task_get_ticks();
 
-  if (event_loop->event_pre_proc_f) event_loop->event_pre_proc_f(event, event_loop->client_data);
+  if (event_loop->event_pre_proc_f)
+    event_loop->event_pre_proc_f(event, event_loop->client_data);
 
   for (uint32_t i = 0; i < event_loop->num_machines; i++) {
     state_machine_handle_event(&event_loop->p_sm[i], event);
@@ -169,87 +177,89 @@ void state_event_loop_exec_queue_f(void *arg1, void *arg2)
   state_event_loop_release_event(event_loop, event);
 }
 
-state_event_registration_t *state_event_loop_allocate_registration(state_event_loop_t * event_loop)
-{
+state_event_registration_t *state_event_loop_allocate_registration(state_event_loop_t *event_loop) {
   state_event_registration_t *retval = 0;
 
   if (event_loop) {
-    retval = (state_event_registration_t *) notifier_allocate_notification_block(event_loop->notifier);
+    retval =
+        (state_event_registration_t *)notifier_allocate_notification_block(event_loop->notifier);
   }
   return retval;
 }
 
-bool state_event_loop_register_notification(state_event_loop_t * event_loop,
-                                            uint32_t event_type, state_event_registration_t * p_reg)
-{
+bool state_event_loop_register_notification(state_event_loop_t *event_loop,
+                                            uint32_t event_type,
+                                            state_event_registration_t *p_reg) {
   bool retval = false;
 
-  if (event_loop &&
-      p_reg && notifier_register_notification_block(event_loop->notifier, event_type, &p_reg->base)) {
+  if (event_loop && p_reg &&
+      notifier_register_notification_block(event_loop->notifier, event_type, &p_reg->base)) {
     p_reg->p_event_loop = event_loop;
     retval = true;
   }
   return retval;
 }
 
-void state_event_loop_deregister_notification(state_event_loop_t * event_loop,
-                                              state_event_registration_t * p_reg)
-{
+void state_event_loop_deregister_notification(state_event_loop_t *event_loop,
+                                              state_event_registration_t *p_reg) {
   if (event_loop && p_reg) {
     notifier_deregister_notification_block(event_loop->notifier, &p_reg->base);
   }
 }
 
-uint32_t state_event_loop_get_current_state_id(state_event_loop_t* event_loop, uint32_t state_mac_index)
-{
-  CUTILS_ASSERTF(event_loop &&
-               state_mac_index < event_loop->num_machines &&
-               event_loop->p_sm[state_mac_index].current_state, "Invalid Inputs");
+uint32_t state_event_loop_get_current_state_id(state_event_loop_t *event_loop,
+                                               uint32_t state_mac_index) {
+  CUTILS_ASSERTF(event_loop && state_mac_index < event_loop->num_machines &&
+                     event_loop->p_sm[state_mac_index].current_state,
+                 "Invalid Inputs");
   return event_loop->p_sm[state_mac_index].current_state->stateId;
 }
 
-state_t* state_event_loop_get_current_state(state_event_loop_t* event_loop, uint32_t state_mac_index)
-{
-  CUTILS_ASSERTF(event_loop &&
-               state_mac_index < event_loop->num_machines, "Invalid Inputs");
+state_t *state_event_loop_get_current_state(state_event_loop_t *event_loop,
+                                            uint32_t state_mac_index) {
+  CUTILS_ASSERTF(event_loop && state_mac_index < event_loop->num_machines, "Invalid Inputs");
   return event_loop->p_sm[state_mac_index].current_state;
 }
 
-uint32_t state_event_loop_state_prefix(logger_t* p_logger, void* p_private, char* p_string, uint32_t string_size)
-{
+uint32_t state_event_loop_state_prefix(logger_t *p_logger,
+                                       void *p_private,
+                                       char *p_string,
+                                       uint32_t string_size) {
   uint32_t retval = 0;
-  state_t* state = (state_t*)((void*)p_logger - offsetof(state_t, log));
-  event_t* p_event = (event_t*)p_private;
+  state_t *state = (state_t *)((void *)p_logger - offsetof(state_t, log));
+  event_t *p_event = (event_t *)p_private;
 
-  if(string_size > strlen(state->state_name)) {
+  if (string_size > strlen(state->state_name)) {
     INSERT_TO_STRING(p_string, retval, "%s: ", state->state_name);
   }
-  if( p_event && p_event->to_string) {
-    //An Event has been supplied.
+  if (p_event && p_event->to_string) {
+    // An Event has been supplied.
     retval += p_event->to_string(p_event, p_string + retval, string_size - retval);
   }
 
   return retval;
 }
 
-static uint32_t state_event_loop_logger_prefix(logger_t* logger, void* client_data, char* str, uint32_t string_size)
-{
+static uint32_t state_event_loop_logger_prefix(logger_t *logger,
+                                               void *client_data,
+                                               char *str,
+                                               uint32_t string_size) {
   uint32_t retval = 0;
-  state_event_loop_t *p_event_loop = (state_event_loop_t*)((void*)logger - offsetof(state_event_loop_t, log));
+  state_event_loop_t *p_event_loop =
+      (state_event_loop_t *)((void *)logger - offsetof(state_event_loop_t, log));
   INSERT_TO_STRING(str, retval, "%s", p_event_loop->name);
-  for(uint32_t i = 0; i < p_event_loop->num_machines; i++) {
-    if(p_event_loop->p_sm && p_event_loop->p_sm[i].current_state) {
-      INSERT_TO_STRING(str,  retval,":%s", p_event_loop->p_sm[i].current_state->state_name);
+  for (uint32_t i = 0; i < p_event_loop->num_machines; i++) {
+    if (p_event_loop->p_sm && p_event_loop->p_sm[i].current_state) {
+      INSERT_TO_STRING(str, retval, ":%s", p_event_loop->p_sm[i].current_state->state_name);
     }
   }
-  if(client_data) {
-    //Event has been provided
-    event_t* event = (event_t*)client_data;
-    if(event->to_string) {
+  if (client_data) {
+    // Event has been provided
+    event_t *event = (event_t *)client_data;
+    if (event->to_string) {
       INSERT_TO_STRING(str, retval, ":");
       retval += event->to_string(event, &str[retval], string_size - retval);
     }
   }
   return retval;
 }
-

--- a/src/state_machine.c
+++ b/src/state_machine.c
@@ -25,30 +25,32 @@
 #include <cutils/state_machine.h>
 #include <string.h>
 
-#define SM_LOG(str, ...)      console_log( &state_mac->logger, state_mac, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__ )
-//TODO: Reenable this
+#define SM_LOG(str, ...)                                                                           \
+  console_log(&state_mac->logger, state_mac, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+// TODO: Reenable this
 #define SM_SLOG(str, ...)
-//system_log( &state_mac->logger, state_mac, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__ )
-#define SM_DEFAULT_LOGGING          (true)
+// system_log( &state_mac->logger, state_mac, "%s(%u): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__
+// )
+#define SM_DEFAULT_LOGGING (true)
 
-static uint32_t StateMachinePrefix(logger_t * logger, void *priv, char *str, uint32_t str_size)
-{
+static uint32_t StateMachinePrefix(logger_t *logger, void *priv, char *str, uint32_t str_size) {
   uint32_t retval = 0;
-  state_machine_t *state_mac = (state_machine_t *) priv;
+  state_machine_t *state_mac = (state_machine_t *)priv;
 
-  INSERT_TO_STRING(str, retval, "%s: %s", state_mac->p_name,
+  INSERT_TO_STRING(str,
+                   retval,
+                   "%s: %s",
+                   state_mac->p_name,
                    (state_mac->current_state) ? state_mac->current_state->state_name : "NoState");
   return retval;
 }
 
-static void state_machine_initialize(state_machine_t * pSm)
-{
+static void state_machine_initialize(state_machine_t *pSm) {
   memset(pSm, 0, sizeof(state_machine_t));
 }
 
-state_machine_t* state_machine_create(state_machine_create_params_t *params)
-{
-  state_machine_t* state_mac = 0;
+state_machine_t *state_machine_create(state_machine_create_params_t *params) {
+  state_machine_t *state_mac = 0;
   CUTILS_ASSERT(params && params->p_state_mac);
   state_mac = params->p_state_mac;
   state_machine_initialize(state_mac);
@@ -62,8 +64,7 @@ state_machine_t* state_machine_create(state_machine_create_params_t *params)
   return state_mac;
 }
 
-state_t *state_machine_get_state(state_machine_t * state_mac, uint32_t stateId)
-{
+state_t *state_machine_get_state(state_machine_t *state_mac, uint32_t stateId) {
   state_t *pRetval = NULL;
   uint32_t i = 0;
 
@@ -77,17 +78,16 @@ state_t *state_machine_get_state(state_machine_t * state_mac, uint32_t stateId)
   return pRetval;
 }
 
-static inline void enter_state(state_machine_t *state_mac, state_t *state)
-{
-  if(!state->entered_once)  {
+static inline void enter_state(state_machine_t *state_mac, state_t *state) {
+  if (!state->entered_once) {
     state->entered_once = true;
-    if( state->f_init ) state->f_init(state_mac, state);
+    if (state->f_init)
+      state->f_init(state_mac, state);
   }
   state->f_enter(state_mac, state);
 }
 
-void state_machine_start(state_machine_t *state_mac)
-{
+void state_machine_start(state_machine_t *state_mac) {
   state_t *pInitialState = state_machine_get_state(state_mac, state_mac->start_state_id);
 
   // Set up the first state to load the state machine
@@ -101,8 +101,7 @@ void state_machine_start(state_machine_t *state_mac)
   enter_state(state_mac, state_mac->current_state);
 }
 
-void state_machine_stop(state_machine_t * state_mac)
-{
+void state_machine_stop(state_machine_t *state_mac) {
   if (state_mac) {
     SM_SLOG("Stopping State Machine");
     if (state_mac->current_state) {
@@ -114,8 +113,7 @@ void state_machine_stop(state_machine_t * state_mac)
   }
 }
 
-void state_machine_register_state(state_machine_t * state_mac, state_t * state)
-{
+void state_machine_register_state(state_machine_t *state_mac, state_t *state) {
   if (state_mac && state && (state_mac->num_of_states < STATE_MAC_MAX_STATES)) {
     // Confirm presence of necessary functions
     CUTILS_ASSERT(state->f_enter);
@@ -127,12 +125,11 @@ void state_machine_register_state(state_machine_t * state_mac, state_t * state)
   }
 }
 
-void state_machine_handle_event(state_machine_t * state_mac, void *event)
-{
+void state_machine_handle_event(state_machine_t *state_mac, void *event) {
   if (event && state_mac->state_machine_started) {
     if (state_mac->current_state->f_valid_event(state_mac, state_mac->current_state, event)) {
       state_mac->next_state_requested =
-        state_mac->current_state->f_handle_event(state_mac, state_mac->current_state, event);
+          state_mac->current_state->f_handle_event(state_mac, state_mac->current_state, event);
 
       // Will transition when event handling is completed and StateTransition() is invoked.
       if (state_mac->next_state_requested != state_mac->current_state->stateId) {
@@ -142,8 +139,7 @@ void state_machine_handle_event(state_machine_t * state_mac, void *event)
   }
 }
 
-void state_machine_transition(state_machine_t * state_mac)
-{
+void state_machine_transition(state_machine_t *state_mac) {
   if (state_mac->transition_requested && state_mac->state_machine_started) {
     state_mac->transition_requested = false;
 
@@ -162,14 +158,12 @@ void state_machine_transition(state_machine_t * state_mac)
   }
 }
 
-void* state_machine_get_private_data(state_machine_t* state_mac)
-{
+void *state_machine_get_private_data(state_machine_t *state_mac) {
   CUTILS_ASSERTF(state_mac, "Valid State Machine required");
   return state_mac->p_private;
 }
 
-void state_machine_set_private_data(state_machine_t* state_mac, void* private)
-{
+void state_machine_set_private_data(state_machine_t *state_mac, void *private) {
   CUTILS_ASSERTF(state_mac, "Valid State Machine required");
   state_mac->p_private = private;
 }

--- a/src/ts_log_buffer.c
+++ b/src/ts_log_buffer.c
@@ -25,8 +25,7 @@
 #include <cutils/ts_log_buffer.h>
 #include <stdio.h>
 
-bool ts_log_buffer_init(ts_log_buffer_t *pLb, char *pBuffer, uint32_t bufferSize)
-{
+bool ts_log_buffer_init(ts_log_buffer_t *pLb, char *pBuffer, uint32_t bufferSize) {
   bool retval = false;
 
   if (pLb) {
@@ -37,22 +36,21 @@ bool ts_log_buffer_init(ts_log_buffer_t *pLb, char *pBuffer, uint32_t bufferSize
   return retval;
 }
 
-void ts_log_buffer_deinit(ts_log_buffer_t *pLb)
-{
+void ts_log_buffer_deinit(ts_log_buffer_t *pLb) {
   if (pLb) {
     mutex_free(&pLb->mtx);
   }
 }
 
-void ts_log_buffer_push(ts_log_buffer_t *p_ts_log, char *string, uint32_t string_size)
-{
+void ts_log_buffer_push(ts_log_buffer_t *p_ts_log, char *string, uint32_t string_size) {
   if (p_ts_log) {
     mutex_lock(&p_ts_log->mtx, WAIT_FOREVER);
     if (p_ts_log->lb.isInit) {
       log_buffer_push(&p_ts_log->lb, string, string_size);
       ts_log_buffer_f fn = p_ts_log->fn;
       void *private = p_ts_log->private;
-      uint32_t used_lines = log_buffer_lines_from_size(log_buffer_current_size(&p_ts_log->lb, NULL, NULL));
+      uint32_t used_lines =
+          log_buffer_lines_from_size(log_buffer_current_size(&p_ts_log->lb, NULL, NULL));
       const uint32_t max_lines = log_buffer_lines_from_size(p_ts_log->lb.bufferSize) - 1;
       int32_t diff = max_lines - used_lines;
 
@@ -69,8 +67,9 @@ void ts_log_buffer_push(ts_log_buffer_t *p_ts_log, char *string, uint32_t string
   }
 }
 
-void ts_log_buffer_install_notifications(ts_log_buffer_t *p_ts_log, ts_log_buffer_f fn, void *private)
-{
+void ts_log_buffer_install_notifications(ts_log_buffer_t *p_ts_log,
+                                         ts_log_buffer_f fn,
+                                         void *private) {
   if (p_ts_log) {
     mutex_lock(&p_ts_log->mtx, WAIT_FOREVER);
     p_ts_log->fn = fn;
@@ -79,8 +78,9 @@ void ts_log_buffer_install_notifications(ts_log_buffer_t *p_ts_log, ts_log_buffe
   }
 }
 
-uint32_t ts_log_buffer_current_size(ts_log_buffer_t *p_lb, uint32_t *initial_bytes, uint32_t *residual_bytes)
-{
+uint32_t ts_log_buffer_current_size(ts_log_buffer_t *p_lb,
+                                    uint32_t *initial_bytes,
+                                    uint32_t *residual_bytes) {
   uint32_t retval = 0;
 
   if (p_lb) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,12 +2,13 @@ enable_language(CXX C)
 
 include(FetchContent)
 FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        v1.17.0
-)
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.17.0)
 # Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(gtest_force_shared_crt
+    ON
+    CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 include(TestUtil)
@@ -23,12 +24,12 @@ target_compile_features(mem_ring_buf_test PRIVATE cxx_std_17)
 target_include_directories(mem_ring_buf_test PRIVATE "${LIBRARY_INCLUDE_DIR}")
 target_link_libraries(mem_ring_buf_test cutils)
 
-package_add_test( os_test os_test.cpp )
+package_add_test(os_test os_test.cpp)
 target_compile_features(os_test PRIVATE cxx_std_17 c_std_11)
 target_include_directories(os_test PRIVATE "${LIBRARY_INCLUDE_DIR}")
 target_link_libraries(os_test cutils)
 
-package_add_test( queue_tests queue_tests.cpp)
+package_add_test(queue_tests queue_tests.cpp)
 target_compile_features(queue_tests PRIVATE cxx_std_17 c_std_11)
 target_include_directories(queue_tests PRIVATE "${LIBRARY_INCLUDE_DIR}")
 target_link_libraries(queue_tests cutils)
@@ -40,39 +41,45 @@ target_include_directories(all_tests PRIVATE "${LIBRARY_INCLUDE_DIR}")
 target_link_libraries(all_tests cutils)
 
 add_executable(pool_tests pool_tests.c)
-target_include_directories(pool_tests PRIVATE "${PROJECT_SOURCE_DIR}/extern/embunit" "${LIBRARY_INCLUDE_DIR}")
+target_include_directories(pool_tests PRIVATE "${PROJECT_SOURCE_DIR}/extern/embunit"
+                                              "${LIBRARY_INCLUDE_DIR}")
 target_link_libraries(pool_tests cutils embunit)
 target_compile_features(pool_tests PRIVATE c_std_11)
 
 add_executable(dispatch_queue_tests dispatch_queue_tests.c)
-target_include_directories(dispatch_queue_tests PRIVATE "${PROJECT_SOURCE_DIR}/extern/embunit" "${LIBRARY_INCLUDE_DIR}")
+target_include_directories(dispatch_queue_tests PRIVATE "${PROJECT_SOURCE_DIR}/extern/embunit"
+                                                        "${LIBRARY_INCLUDE_DIR}")
 target_link_libraries(dispatch_queue_tests cutils embunit)
 target_compile_features(dispatch_queue_tests PRIVATE c_std_11)
 
-
-# The following unit test uses Malloc and so will only be available on platforms that support malloc.h
-CHECK_INCLUDE_FILE(malloc.h HAVE_MALLOC_H)
-CHECK_INCLUDE_FILE(stdlib.h HAVE_STDLIB_H)
+# The following unit test uses Malloc and so will only be available on platforms that support
+# malloc.h
+check_include_file(malloc.h HAVE_MALLOC_H)
+check_include_file(stdlib.h HAVE_STDLIB_H)
 if(HAVE_MALLOC_H)
-if(HAVE_STDLIB_H)
-  add_executable(notifier_tests notifier_tests.c)
-  target_include_directories(notifier_tests PRIVATE "${PROJECT_SOURCE_DIR}/extern/embunit" "${LIBRARY_INCLUDE_DIR}")
-  target_link_libraries(notifier_tests cutils embunit)
-  target_compile_features(notifier_tests PRIVATE c_std_11)
-endif()
+  if(HAVE_STDLIB_H)
+    add_executable(notifier_tests notifier_tests.c)
+    target_include_directories(notifier_tests PRIVATE "${PROJECT_SOURCE_DIR}/extern/embunit"
+                                                      "${LIBRARY_INCLUDE_DIR}")
+    target_link_libraries(notifier_tests cutils embunit)
+    target_compile_features(notifier_tests PRIVATE c_std_11)
+  endif()
 endif()
 
 add_executable(accumulator_tests accumulator_tests.c)
-target_include_directories(accumulator_tests PRIVATE "${PROJECT_SOURCE_DIR}/extern/embunit" "${LIBRARY_INCLUDE_DIR}")
+target_include_directories(accumulator_tests PRIVATE "${PROJECT_SOURCE_DIR}/extern/embunit"
+                                                     "${LIBRARY_INCLUDE_DIR}")
 target_link_libraries(accumulator_tests cutils embunit)
 target_compile_features(accumulator_tests PRIVATE c_std_11)
 
 add_executable(asyncio_tests asyncio_test.c)
-target_include_directories(asyncio_tests PRIVATE "${PROJECT_SOURCE_DIR}/extern/embunit" "${LIBRARY_INCLUDE_DIR}")
+target_include_directories(asyncio_tests PRIVATE "${PROJECT_SOURCE_DIR}/extern/embunit"
+                                                 "${LIBRARY_INCLUDE_DIR}")
 target_link_libraries(asyncio_tests cutils embunit)
 target_compile_features(asyncio_tests PRIVATE c_std_11)
 
 add_executable(state_event_loop_tests state_event_loop_tests.c)
-target_include_directories(state_event_loop_tests PRIVATE "${PROJECT_SOURCE_DIR}/extern/embunit" "${LIBRARY_INCLUDE_DIR}")
+target_include_directories(state_event_loop_tests PRIVATE "${PROJECT_SOURCE_DIR}/extern/embunit"
+                                                          "${LIBRARY_INCLUDE_DIR}")
 target_link_libraries(state_event_loop_tests cutils embunit)
 target_compile_features(state_event_loop_tests PRIVATE c_std_11)

--- a/tests/accumulator_tests.c
+++ b/tests/accumulator_tests.c
@@ -22,26 +22,23 @@
  * THE SOFTWARE.
  */
 
-#include <embUnit/embUnit.h>
 #include <cutils/accumulator.h>
+#include <embUnit/embUnit.h>
 
 ACCUMULATOR_STORE_DECL(test, 6);
 ACCUMULATOR_STORE_DEF(test);
 static accumulator_h s_test_handle;
 
-static void setup(void)
-{
+static void setup(void) {
   accumulator_create_params_t params = {0};
   ACCUMULATOR_CREATE_PARAMS_INIT(params, test);
 
   s_test_handle = accumulator_create(&params);
 }
 
-static void teardown(void)
-{}
+static void teardown(void) {}
 
-static void check_acc_api(void)
-{
+static void check_acc_api(void) {
   accumulator_h handle = s_test_handle;
   TEST_ASSERT(handle);
   uint8_t test_bufA[] = {1, 2};
@@ -63,8 +60,7 @@ static void check_acc_api(void)
   TEST_ASSERT(accumulator_bytes_contained(handle) == 0);
 }
 
-static void check_wrap_around(void)
-{
+static void check_wrap_around(void) {
   accumulator_h handle = s_test_handle;
 
   TEST_ASSERT(handle);
@@ -78,7 +74,7 @@ static void check_wrap_around(void)
   TEST_ASSERT(!memcmp(read_buf, test_bufA, sizeof(test_bufA)));
   memset(read_buf, 0, sizeof(read_buf));
 
-  //Add a 6
+  // Add a 6
   uint8_t add_one = 6;
   TEST_ASSERT(accumulator_insert(handle, &add_one, sizeof(add_one)));
   TEST_ASSERT(accumulator_peek(handle, read_buf, sizeof(read_buf)));
@@ -88,11 +84,11 @@ static void check_wrap_around(void)
   uint8_t add_two[] = {7, 8};
   TEST_ASSERT(accumulator_insert(handle, add_two, sizeof(add_two)));
   TEST_ASSERT(accumulator_peek(handle, read_buf, sizeof(read_buf)));
-  TEST_ASSERT(read_buf[0] == 4 && read_buf[1] == 5 && read_buf[2] == 6 && read_buf[3] == 7 && read_buf[4] == 8);
+  TEST_ASSERT(read_buf[0] == 4 && read_buf[1] == 5 && read_buf[2] == 6 && read_buf[3] == 7 &&
+              read_buf[4] == 8);
 }
 
-static void check_iterator(void)
-{
+static void check_iterator(void) {
   accumulator_h handle = s_test_handle;
 
   TEST_ASSERT(handle);
@@ -110,8 +106,7 @@ static void check_iterator(void)
   TEST_ASSERT(!accumulator_iterator_next(handle, &iter));
 }
 
-static void check_iterator_advances_to_the_end(void)
-{
+static void check_iterator_advances_to_the_end(void) {
   accumulator_h handle = s_test_handle;
   uint8_t test_bufA[] = {1, 2, 3, 4, 5};
   TEST_ASSERT(accumulator_insert(handle, test_bufA, sizeof(test_bufA)));
@@ -124,20 +119,17 @@ static void check_iterator_advances_to_the_end(void)
   TEST_ASSERT(val == 5);
 }
 
-TestRef accumulator_get_tests(void)
-{
-  EMB_UNIT_TESTFIXTURES(fixture) {
+TestRef accumulator_get_tests(void) {
+  EMB_UNIT_TESTFIXTURES(fixture){
       new_TestFixture("Accumulator API Tests 1", check_acc_api),
       new_TestFixture("Accumulator Wraps around", check_wrap_around),
       new_TestFixture("Accumulator Iterator Works", check_iterator),
-      new_TestFixture("Iterator advances to end", check_iterator_advances_to_the_end)
-  };
+      new_TestFixture("Iterator advances to end", check_iterator_advances_to_the_end)};
   EMB_UNIT_TESTCALLER(accumulator_tests, "Accumulator tests", setup, teardown, fixture);
-  return (TestRef) &accumulator_tests;
+  return (TestRef)&accumulator_tests;
 }
 
-int main()
-{
+int main() {
   TestRunner_start();
   {
     TestRunner_runTest(accumulator_get_tests());

--- a/tests/asyncio_test.c
+++ b/tests/asyncio_test.c
@@ -22,50 +22,49 @@
  * THE SOFTWARE.
  */
 
-#include <embUnit/embUnit.h>
-#include <cutils/asyncio.h>
 #include <cutils/accumulator.h>
+#include <cutils/asyncio.h>
+#include <embUnit/embUnit.h>
 #include <inttypes.h>
 #include <stdlib.h>
 
-#define MESSAGE_BUF_SIZE        ( 64 )
+#define MESSAGE_BUF_SIZE (64)
 ASYNCIO_STORE_DECL(testio, 16, 16, MESSAGE_BUF_SIZE, MESSAGE_BUF_SIZE, 16);
 ASYNCIO_STORE_DEF(testio);
 
-ASYNCIO_STORE_DECL(tx_only_test, ASYNCIO_SERVICE_UNUSED, 2, ASYNCIO_SERVICE_UNUSED, MESSAGE_BUF_SIZE, 16);
+ASYNCIO_STORE_DECL(
+    tx_only_test, ASYNCIO_SERVICE_UNUSED, 2, ASYNCIO_SERVICE_UNUSED, MESSAGE_BUF_SIZE, 16);
 ASYNCIO_STORE_DEF(tx_only_test);
 
 ACCUMULATOR_STORE_DECL(test_acc, 1024);
 ACCUMULATOR_STORE_DEF(test_acc);
 
-DISPATCH_QUEUE_STORE_DECL(asyncio_rx_q, 4, 64*1024);
+DISPATCH_QUEUE_STORE_DECL(asyncio_rx_q, 4, 64 * 1024);
 DISPATCH_QUEUE_STORE_DEF(asyncio_rx_q);
 
-DISPATCH_QUEUE_STORE_DECL(asyncio_tx_q, 4, 64*1024);
+DISPATCH_QUEUE_STORE_DECL(asyncio_tx_q, 4, 64 * 1024);
 DISPATCH_QUEUE_STORE_DEF(asyncio_tx_q);
 
+#define BUF_AVAIL_TO_READ (1 << 0)
+#define TEST_COMPLETE (1 << 1)
 
-#define BUF_AVAIL_TO_READ     ( 1 << 0 )
-#define TEST_COMPLETE         ( 1 << 1 )
-
-#define TEST_STATUS_E(XX)\
-  XX( TestPassed, = 0)\
-  XX( TestContinuing, )\
-  XX( TestFailedUnexpectedBufferSize, )\
-  XX( TestFailedCrcMismatch, )\
-  XX( TestFaileToAllocateToken, )\
-  XX( TestFailedBadBufferInToken, )\
-  XX( TestFailedSendData, )
+#define TEST_STATUS_E(XX)                                                                          \
+  XX(TestPassed, = 0)                                                                              \
+  XX(TestContinuing, )                                                                             \
+  XX(TestFailedUnexpectedBufferSize, )                                                             \
+  XX(TestFailedCrcMismatch, )                                                                      \
+  XX(TestFaileToAllocateToken, )                                                                   \
+  XX(TestFailedBadBufferInToken, )                                                                 \
+  XX(TestFailedSendData, )
 
 DECLARE_ENUM(testio_test_status_e, TEST_STATUS_E)
 
-typedef struct
-{
+typedef struct {
   uint32_t signature;
   event_flag_t evt;
   accumulator_h acc;
-  dispatch_queue_t* tx_queue;
-  dispatch_queue_t* rx_queue;
+  dispatch_queue_t *tx_queue;
+  dispatch_queue_t *rx_queue;
   uint8_t tempBuf[MESSAGE_BUF_SIZE];
   testio_test_status_e status;
   char err_str[256];
@@ -76,60 +75,63 @@ typedef struct
 static testio_data_t s_data = {.signature = 0xDEADBEEF, .total_num_of_test_packets = 30};
 
 static uint32_t crc32_for_byte(uint32_t r) {
-  for(int j = 0; j < 8; ++j)
-    r = (r & 1? 0: (uint32_t)0xEDB88320L) ^ r >> 1;
+  for (int j = 0; j < 8; ++j)
+    r = (r & 1 ? 0 : (uint32_t)0xEDB88320L) ^ r >> 1;
   return r ^ (uint32_t)0xFF000000L;
 }
 
-static void crc32(const void *data, size_t n_bytes, uint32_t* crc) {
+static void crc32(const void *data, size_t n_bytes, uint32_t *crc) {
   static uint32_t table[0x100];
-  if(!*table)
-    for(size_t i = 0; i < 0x100; ++i)
+  if (!*table)
+    for (size_t i = 0; i < 0x100; ++i)
       table[i] = crc32_for_byte(i);
-  for(size_t i = 0; i < n_bytes; ++i)
-    *crc = table[(uint8_t)*crc ^ ((uint8_t*)data)[i]] ^ *crc >> 8;
+  for (size_t i = 0; i < n_bytes; ++i)
+    *crc = table[(uint8_t)*crc ^ ((uint8_t *)data)[i]] ^ *crc >> 8;
 }
 
-static inline void generate_random_payload(uint32_t* buf)
-{
+static inline void generate_random_payload(uint32_t *buf) {
   if (buf) {
-      for (uint32_t i = 0; i < (MESSAGE_BUF_SIZE - sizeof(uint32_t)) / sizeof(uint32_t); i++) {
-        buf[i] = (uint32_t) rand();
-      }
+    for (uint32_t i = 0; i < (MESSAGE_BUF_SIZE - sizeof(uint32_t)) / sizeof(uint32_t); i++) {
+      buf[i] = (uint32_t)rand();
+    }
   }
 }
 
-static size_t validate_accumulator(testio_data_t *p_data)
-{
+static size_t validate_accumulator(testio_data_t *p_data) {
   size_t retval = accumulator_bytes_contained(p_data->acc);
   if (retval <= MESSAGE_BUF_SIZE) {
     uint32_t crc = 0;
 
-    accumulator_extract(p_data->acc, (uint8_t *) &crc, sizeof(crc));
-    accumulator_extract(p_data->acc, p_data->tempBuf, (uint32_t) (retval - sizeof(crc)));
+    accumulator_extract(p_data->acc, (uint8_t *)&crc, sizeof(crc));
+    accumulator_extract(p_data->acc, p_data->tempBuf, (uint32_t)(retval - sizeof(crc)));
 
     uint32_t calculated_crc = 0;
-    crc32(p_data->tempBuf, (uint32_t) (retval - sizeof(crc)), &calculated_crc);
+    crc32(p_data->tempBuf, (uint32_t)(retval - sizeof(crc)), &calculated_crc);
 
     if (calculated_crc != crc) {
       p_data->status = TestFailedCrcMismatch;
-      snprintf(p_data->err_str, sizeof(p_data->err_str),
-               "Crc Mismatch - Expected = 0x%"PRIx32", Got = 0x%"PRIx32, crc, calculated_crc);
+      snprintf(p_data->err_str,
+               sizeof(p_data->err_str),
+               "Crc Mismatch - Expected = 0x%" PRIx32 ", Got = 0x%" PRIx32,
+               crc,
+               calculated_crc);
     } else {
       p_data->status = TestContinuing;
     }
   } else {
     p_data->status = TestFailedUnexpectedBufferSize;
-    snprintf(p_data->err_str, sizeof(p_data->err_str), "Recd: %"PRIu64" bytes, expected %"PRIu32" bytes",
-             retval, MESSAGE_BUF_SIZE);
+    snprintf(p_data->err_str,
+             sizeof(p_data->err_str),
+             "Recd: %" PRIu64 " bytes, expected %" PRIu32 " bytes",
+             retval,
+             MESSAGE_BUF_SIZE);
   }
   return retval;
 }
 
-static size_t testio_read_f(asyncio_handle_t handle, uint8_t *p_rx_data_buf, uint32_t timeout)
-{
+static size_t testio_read_f(asyncio_handle_t handle, uint8_t *p_rx_data_buf, uint32_t timeout) {
   size_t retval = 0;
-  testio_data_t *p_data = (testio_data_t *) asyncio_get_private_data(handle);
+  testio_data_t *p_data = (testio_data_t *)asyncio_get_private_data(handle);
   uint32_t act_flags = 0;
 
   if (event_flag_wait(&p_data->evt, BUF_AVAIL_TO_READ, WAIT_OR_CLEAR, &act_flags, timeout)) {
@@ -142,23 +144,25 @@ static size_t testio_read_f(asyncio_handle_t handle, uint8_t *p_rx_data_buf, uin
 static size_t testio_write_f(asyncio_handle_t handle,
                              size_t tx_data_size,
                              uint8_t *p_tx_data_buf,
-                             uint32_t timeout)
-{
+                             uint32_t timeout) {
   size_t retval = 0;
-  testio_data_t *p_data = (testio_data_t *) asyncio_get_private_data(handle);
+  testio_data_t *p_data = (testio_data_t *)asyncio_get_private_data(handle);
 
   if (tx_data_size <= MESSAGE_BUF_SIZE - sizeof(uint32_t)) {
     uint32_t crc = 0;
     crc32(p_tx_data_buf, tx_data_size, &crc);
 
-    accumulator_insert(p_data->acc, (uint8_t *) &crc, sizeof(crc));
+    accumulator_insert(p_data->acc, (uint8_t *)&crc, sizeof(crc));
     accumulator_insert(p_data->acc, p_tx_data_buf, tx_data_size);
     event_flag_send(&p_data->evt, BUF_AVAIL_TO_READ);
     retval = tx_data_size;
   } else {
     p_data->status = TestFailedUnexpectedBufferSize;
-    snprintf(p_data->err_str, sizeof(p_data->err_str), "Trying to send %"PRIu64" bytes when %"PRIu32" is max",
-             tx_data_size, MESSAGE_BUF_SIZE);
+    snprintf(p_data->err_str,
+             sizeof(p_data->err_str),
+             "Trying to send %" PRIu64 " bytes when %" PRIu32 " is max",
+             tx_data_size,
+             MESSAGE_BUF_SIZE);
   }
 
   return retval;
@@ -167,34 +171,37 @@ static size_t testio_write_f(asyncio_handle_t handle,
 static size_t testio_tx_only_write_f(asyncio_handle_t handle,
                                      size_t tx_data_size,
                                      uint8_t *p_tx_data_buf,
-                                     uint32_t timeout)
-{
+                                     uint32_t timeout) {
   size_t retval = 0;
-  //Just going to validate the data.
-  testio_data_t *p_data = (testio_data_t*) asyncio_get_private_data(handle);
+  // Just going to validate the data.
+  testio_data_t *p_data = (testio_data_t *)asyncio_get_private_data(handle);
   if (tx_data_size <= MESSAGE_BUF_SIZE - sizeof(uint32_t)) {
     uint32_t crc = 0;
     crc32(p_tx_data_buf, tx_data_size, &crc);
 
-    accumulator_insert(p_data->acc, (uint8_t *) &crc, sizeof(crc));
+    accumulator_insert(p_data->acc, (uint8_t *)&crc, sizeof(crc));
     accumulator_insert(p_data->acc, p_tx_data_buf, tx_data_size);
     validate_accumulator(p_data);
     retval = tx_data_size;
   } else {
     p_data->status = TestFailedUnexpectedBufferSize;
-    snprintf(p_data->err_str, sizeof(p_data->err_str), "Trying to send %"PRIu64" bytes when %"PRIu32" is max",
-             tx_data_size, MESSAGE_BUF_SIZE);
+    snprintf(p_data->err_str,
+             sizeof(p_data->err_str),
+             "Trying to send %" PRIu64 " bytes when %" PRIu32 " is max",
+             tx_data_size,
+             MESSAGE_BUF_SIZE);
   }
   return retval;
 }
 
-static bool send_random_payload(testio_data_t *p_data, asyncio_handle_t h_asyncio, asyncio_tx_notification_f fn)
-{
+static bool send_random_payload(testio_data_t *p_data,
+                                asyncio_handle_t h_asyncio,
+                                asyncio_tx_notification_f fn) {
   asyncio_tx_token_t token = asyncio_allocate_tx_token(h_asyncio);
   bool retval = false;
   CUTILS_ASSERT(p_data);
   if (token) {
-    uint32_t *buf = (uint32_t *) asyncio_tx_token_get_data_buffer(token);
+    uint32_t *buf = (uint32_t *)asyncio_tx_token_get_data_buffer(token);
     if (buf) {
       generate_random_payload(buf);
       retval = asyncio_send_buffer(h_asyncio, token, MESSAGE_BUF_SIZE - sizeof(uint32_t), fn, NULL);
@@ -209,10 +216,9 @@ static bool send_random_payload(testio_data_t *p_data, asyncio_handle_t h_asynci
   return retval;
 }
 
-static void testio_rx_f(asyncio_handle_t h_asyncio, asyncio_message_t message, size_t size)
-{
+static void testio_rx_f(asyncio_handle_t h_asyncio, asyncio_message_t message, size_t size) {
 
-  testio_data_t *p_data = (testio_data_t *) asyncio_get_private_data(h_asyncio);
+  testio_data_t *p_data = (testio_data_t *)asyncio_get_private_data(h_asyncio);
 
   CUTILS_ASSERTF(p_data, "Private data not supplied in Asyncio RX Callback");
   if (p_data->status == TestContinuing) {
@@ -221,8 +227,11 @@ static void testio_rx_f(asyncio_handle_t h_asyncio, asyncio_message_t message, s
       // Send Random Payload
       if (!send_random_payload(p_data, h_asyncio, NULL)) {
         p_data->status = TestFailedSendData;
-        snprintf(p_data->err_str, sizeof(p_data->err_str), "Failed to send Data chunk: %"PRIu32" / %"PRIu32,
-                 p_data->current_proc_packets, p_data->total_num_of_test_packets);
+        snprintf(p_data->err_str,
+                 sizeof(p_data->err_str),
+                 "Failed to send Data chunk: %" PRIu32 " / %" PRIu32,
+                 p_data->current_proc_packets,
+                 p_data->total_num_of_test_packets);
         event_flag_send(&p_data->evt, TEST_COMPLETE);
       }
     } else {
@@ -234,8 +243,7 @@ static void testio_rx_f(asyncio_handle_t h_asyncio, asyncio_message_t message, s
   }
 }
 
-static void asyncio_loopback_test(void)
-{
+static void asyncio_loopback_test(void) {
   asyncio_create_params_t params;
   TEST_ASSERT(s_data.rx_queue && s_data.tx_queue);
   ASYNCIO_CREATE_PARAMS_INIT(params,
@@ -259,11 +267,7 @@ static void asyncio_loopback_test(void)
     // Wait for the test to complete
     uint32_t act_flags = 0;
 
-    if (!event_flag_wait(&s_data.evt,
-                         TEST_COMPLETE,
-                         WAIT_OR_CLEAR,
-                         &act_flags,
-                         WAIT_FOREVER)) {
+    if (!event_flag_wait(&s_data.evt, TEST_COMPLETE, WAIT_OR_CLEAR, &act_flags, WAIT_FOREVER)) {
       TEST_FAIL("Failed to wait for asyncio test to complete");
     } else {
       TEST_ASSERT_EQUAL_INT(TestPassed, s_data.status);
@@ -275,9 +279,8 @@ static void asyncio_loopback_test(void)
 static void asyncio_tx_only_notification_f(asyncio_tx_token_t token,
                                            asyncio_tx_send_status_e sendStatus,
                                            uint32_t sendSize,
-                                           void *pPrivate)
-{
-  if (s_data.status == TestContinuing ) {
+                                           void *pPrivate) {
+  if (s_data.status == TestContinuing) {
     s_data.current_proc_packets++;
     event_flag_send(&s_data.evt, BUF_AVAIL_TO_READ);
     if (s_data.current_proc_packets == s_data.total_num_of_test_packets) {
@@ -289,8 +292,7 @@ static void asyncio_tx_only_notification_f(asyncio_tx_token_t token,
   }
 }
 
-static void asyncio_tx_only_test(void)
-{
+static void asyncio_tx_only_test(void) {
   uint32_t act_flags = 0;
   asyncio_create_params_t params;
   ASYNCIO_CREATE_PARAMS_INIT(params,
@@ -315,11 +317,7 @@ static void asyncio_tx_only_test(void)
     TEST_ASSERT(event_flag_wait(&s_data.evt, BUF_AVAIL_TO_READ, WAIT_OR_CLEAR, &act_flags, 1000));
   }
   act_flags = 0;
-  if (!event_flag_wait(&s_data.evt,
-                       TEST_COMPLETE,
-                       WAIT_OR_CLEAR,
-                       &act_flags,
-                       WAIT_FOREVER)) {
+  if (!event_flag_wait(&s_data.evt, TEST_COMPLETE, WAIT_OR_CLEAR, &act_flags, WAIT_FOREVER)) {
     TEST_FAIL("Failed to wait for asyncio test to complete");
   } else {
     TEST_ASSERT_EQUAL_INT(TestPassed, s_data.status);
@@ -327,8 +325,7 @@ static void asyncio_tx_only_test(void)
   asyncio_destroy_instance(h_asyncio);
 }
 
-static void setup(void)
-{
+static void setup(void) {
   accumulator_create_params_t acc_params;
 
   event_flag_new(&s_data.evt);
@@ -339,16 +336,17 @@ static void setup(void)
   s_data.current_proc_packets = 0;
   s_data.total_num_of_test_packets = 30;
 
-  dispatch_queue_create_params_t params = { 0 };
-  DISPATCH_QUEUE_CREATE_PARAMS_INIT(params, asyncio_tx_q, "asyncio_test_tx", CUTILS_TASK_PRIORITY_MEDIUM);
+  dispatch_queue_create_params_t params = {0};
+  DISPATCH_QUEUE_CREATE_PARAMS_INIT(
+      params, asyncio_tx_q, "asyncio_test_tx", CUTILS_TASK_PRIORITY_MEDIUM);
   s_data.tx_queue = dispatch_queue_create(&params);
 
-  DISPATCH_QUEUE_CREATE_PARAMS_INIT(params, asyncio_rx_q, "asyncio_test_rx", CUTILS_TASK_PRIORITY_MID_LO);
+  DISPATCH_QUEUE_CREATE_PARAMS_INIT(
+      params, asyncio_rx_q, "asyncio_test_rx", CUTILS_TASK_PRIORITY_MID_LO);
   s_data.rx_queue = dispatch_queue_create(&params);
 }
 
-static void teardown(void)
-{
+static void teardown(void) {
   event_flag_free(&s_data.evt);
   accumulator_clear(s_data.acc);
   dispatch_queue_destroy(s_data.tx_queue);
@@ -356,17 +354,13 @@ static void teardown(void)
   s_data.tx_queue = s_data.rx_queue = 0;
 }
 
-TestRef asyncio_get_tests(void)
-{
-  EMB_UNIT_TESTFIXTURES(fixtures) {
-      new_TestFixture("Test Asyncio Loopback", asyncio_loopback_test),
-      new_TestFixture("Test Asyncio Tx Only", asyncio_tx_only_test)
-  };
+TestRef asyncio_get_tests(void) {
+  EMB_UNIT_TESTFIXTURES(fixtures){new_TestFixture("Test Asyncio Loopback", asyncio_loopback_test),
+                                  new_TestFixture("Test Asyncio Tx Only", asyncio_tx_only_test)};
   EMB_UNIT_TESTCALLER(asyncio_basic_tests, "Asyncio interface Tests", setup, teardown, fixtures);
-  return (TestRef) &asyncio_basic_tests;
+  return (TestRef)&asyncio_basic_tests;
 }
-int main()
-{
+int main() {
   TestRunner_start();
   {
     TestRunner_runTest(asyncio_get_tests());

--- a/tests/dispatch_queue_tests.c
+++ b/tests/dispatch_queue_tests.c
@@ -36,76 +36,71 @@ DISPATCH_QUEUE_STORE_DEF(test_queue_2);
 DISPATCH_QUEUE_STORE_DECL(test_queue_3, 32, 4096);
 DISPATCH_QUEUE_STORE_DEF(test_queue_3);
 
-typedef struct
-{
+typedef struct {
   uint32_t sleep_time;
   uint32_t val;
 } action_data_t;
 
-static void action_1(void *arg1, void *arg2)
-{
-  action_data_t *p_data = (action_data_t *) arg1;
+static void action_1(void *arg1, void *arg2) {
+  action_data_t *p_data = (action_data_t *)arg1;
   task_sleep(p_data->sleep_time);
   p_data->val = 1;
 }
 
-static void test_queue(dispatch_queue_t *p_queue)
-{
+static void test_queue(dispatch_queue_t *p_queue) {
   action_data_t data = {.sleep_time = 5};
   TEST_ASSERT(dispatch_async_f(p_queue, action_1, &data, NULL));
   dispatch_queue_destroy(p_queue);
   TEST_ASSERT_MESSAGE(data.val == 1, "Action should modify test value on dispatch queue");
 }
 
-static void can_create_and_run_action(void)
-{
+static void can_create_and_run_action(void) {
   dispatch_queue_create_params_t params = {0};
   dispatch_queue_t *p_queue = 0;
-  DISPATCH_QUEUE_CREATE_PARAMS_INIT(params, test_queue_1, "test_dispatch_queue1", CUTILS_TASK_PRIORITY_MEDIUM);
+  DISPATCH_QUEUE_CREATE_PARAMS_INIT(
+      params, test_queue_1, "test_dispatch_queue1", CUTILS_TASK_PRIORITY_MEDIUM);
   p_queue = dispatch_queue_create(&params);
   TEST_ASSERT_MESSAGE(p_queue, "Dispatch queue should be created successfully");
   test_queue(p_queue);
   memset(&params, 0, sizeof(params));
 
-  //Task 2
-  DISPATCH_QUEUE_CREATE_PARAMS_INIT(params, test_queue_2, "test_dispatch_queue2", CUTILS_TASK_PRIORITY_MID_HIGH);
+  // Task 2
+  DISPATCH_QUEUE_CREATE_PARAMS_INIT(
+      params, test_queue_2, "test_dispatch_queue2", CUTILS_TASK_PRIORITY_MID_HIGH);
   p_queue = dispatch_queue_create(&params);
   TEST_ASSERT_MESSAGE(p_queue, "Dispatch queue should be created successfully");
   test_queue(p_queue);
   memset(&params, 0, sizeof(params));
 
-  //Task 3
-  DISPATCH_QUEUE_CREATE_PARAMS_INIT(params, test_queue_3, "test_dispatch_queue3", CUTILS_TASK_PRIORITY_MID_HIGH);
+  // Task 3
+  DISPATCH_QUEUE_CREATE_PARAMS_INIT(
+      params, test_queue_3, "test_dispatch_queue3", CUTILS_TASK_PRIORITY_MID_HIGH);
   p_queue = dispatch_queue_create(&params);
   TEST_ASSERT_MESSAGE(p_queue, "Dispatch queue should be created successfully");
   test_queue(p_queue);
   memset(&params, 0, sizeof(params));
 }
 
-typedef struct
-{
+typedef struct {
   dispatch_queue_t *p_queue_hi, *p_queue_lo;
   uint32_t val;
 } task_action_test_data_t;
 
-static void lo_action(void *arg1, void *arg2)
-{
-  task_action_test_data_t *p_data = (task_action_test_data_t *) arg1;
+static void lo_action(void *arg1, void *arg2) {
+  task_action_test_data_t *p_data = (task_action_test_data_t *)arg1;
   p_data->val--;
 }
 
-static void hi_action(void *arg1, void *arg2)
-{
-  task_action_test_data_t *p_data = (task_action_test_data_t *) arg1;
+static void hi_action(void *arg1, void *arg2) {
+  task_action_test_data_t *p_data = (task_action_test_data_t *)arg1;
 
   TEST_ASSERT(p_data);
   p_data->val++;
   p_data->val++;
 }
 
-static void medium_action(void *arg1, void *arg2)
-{
-  task_action_test_data_t *p_data = (task_action_test_data_t *) arg1;
+static void medium_action(void *arg1, void *arg2) {
+  task_action_test_data_t *p_data = (task_action_test_data_t *)arg1;
 
   TEST_ASSERT(p_data);
   for (uint32_t i = 0; i < 4; i++) {
@@ -117,21 +112,23 @@ static void medium_action(void *arg1, void *arg2)
   task_sleep(100);
 }
 
-static void can_post_between_queues(void)
-{
+static void can_post_between_queues(void) {
   task_action_test_data_t data = {0};
   dispatch_queue_t *p_queue_mid = 0;
   dispatch_queue_create_params_t params = {0};
 
-  DISPATCH_QUEUE_CREATE_PARAMS_INIT(params, test_queue_1, "test exec hi", CUTILS_TASK_PRIORITY_HIGHEST);
+  DISPATCH_QUEUE_CREATE_PARAMS_INIT(
+      params, test_queue_1, "test exec hi", CUTILS_TASK_PRIORITY_HIGHEST);
   data.p_queue_hi = dispatch_queue_create(&params);
   TEST_ASSERT(data.p_queue_hi);
 
-  DISPATCH_QUEUE_CREATE_PARAMS_INIT(params, test_queue_2, "test exec mid", CUTILS_TASK_PRIORITY_MEDIUM);
+  DISPATCH_QUEUE_CREATE_PARAMS_INIT(
+      params, test_queue_2, "test exec mid", CUTILS_TASK_PRIORITY_MEDIUM);
   p_queue_mid = dispatch_queue_create(&params);
   TEST_ASSERT(p_queue_mid);
 
-  DISPATCH_QUEUE_CREATE_PARAMS_INIT(params, test_queue_3, "test exec lo", CUTILS_TASK_PRIORITY_MID_LO);
+  DISPATCH_QUEUE_CREATE_PARAMS_INIT(
+      params, test_queue_3, "test exec lo", CUTILS_TASK_PRIORITY_MID_LO);
   data.p_queue_lo = dispatch_queue_create(&params);
   TEST_ASSERT(data.p_queue_lo);
 
@@ -153,9 +150,9 @@ typedef struct _dispatch_queue_isr_test_t
 
 static dispatch_queue_isr_test_t s_isr_test = { 0 };
 
-#define      DQI_TEST_FLAG_ISR_SUCCESS   (1 << 0)
-#define      DQI_TEST_FLAG_ACTION_SUCCESS  (1 << 1)
-#define      DQI_TEST_FLAG_ISR_ERROR     (1 << 2)
+#define DQI_TEST_FLAG_ISR_SUCCESS (1 << 0)
+#define DQI_TEST_FLAG_ACTION_SUCCESS (1 << 1)
+#define DQI_TEST_FLAG_ISR_ERROR (1 << 2)
 
 static void dispatch_isr_test_action(void* arg1, void* arg2)
 {
@@ -209,9 +206,9 @@ typedef struct _dispatch_queue_app_timer_test_t
   event_flag_t flag;
 } dispatch_queue_app_timer_test_t;
 
-#define      DQAT_TEST_FLAG_TIMER_SUCCESS   (1 << 0)
-#define      DQAT_TEST_FLAG_ACTION_SUCCESS  (1 << 1)
-#define      DQAT_TEST_FLAG_TIMER_ERROR     (1 << 2)
+#define DQAT_TEST_FLAG_TIMER_SUCCESS (1 << 0)
+#define DQAT_TEST_FLAG_ACTION_SUCCESS (1 << 1)
+#define DQAT_TEST_FLAG_TIMER_ERROR (1 << 2)
 
 static void dispatch_app_timer_test_action(void *arg1, void *arg2)
 {
@@ -261,18 +258,14 @@ static void can_post_from_application_timer_callback(void)
   TEST_ASSERT(atomic_load_explicit(&s_timer_test.val, memory_order_acquire) == 1);
 }
 #endif
-static void setup(void)
-{
-}
+static void setup(void) {}
 
-static void teardown(void)
-{
-}
+static void teardown(void) {}
 
-TestRef dispatch_queue_get_tests(void)
-{
-  EMB_UNIT_TESTFIXTURES(fixture) {
-      new_TestFixture("Can Create and run an action on three different dispatch queues", can_create_and_run_action),
+TestRef dispatch_queue_get_tests(void) {
+  EMB_UNIT_TESTFIXTURES(fixture){
+      new_TestFixture("Can Create and run an action on three different dispatch queues",
+                      can_create_and_run_action),
       new_TestFixture("Can post between queues", can_post_between_queues),
 #if 0
       new_TestFixture("Can post from isr", can_post_from_isr),
@@ -280,7 +273,7 @@ TestRef dispatch_queue_get_tests(void)
 #endif
   };
   EMB_UNIT_TESTCALLER(dispatch_queue_tests, "dispatch_queue_tests", setup, teardown, fixture);
-  return (TestRef) &dispatch_queue_tests;
+  return (TestRef)&dispatch_queue_tests;
 }
 #if 0
 typedef struct _dispatch_after_test_data_t

--- a/tests/klist_test.cpp
+++ b/tests/klist_test.cpp
@@ -22,8 +22,8 @@
  * THE SOFTWARE.
  */
 
-#include <gtest/gtest.h>
 #include <cutils/klist.h>
+#include <gtest/gtest.h>
 
 namespace tests {
 class KlistTest : public ::testing::Test {
@@ -43,24 +43,24 @@ TEST_F(KlistTest, MustInsert) {
   TestObj bufs[10];
   memset(bufs, 0, sizeof(bufs));
   KListHead *p_head = nullptr;
-  for(uint32_t i = 0 ; i < sizeof(bufs)/sizeof(bufs[0]); i++) {
+  for (uint32_t i = 0; i < sizeof(bufs) / sizeof(bufs[0]); i++) {
     bufs[i].val = 10 + i;
     KLIST_HEAD_PREPEND(p_head, &bufs[i].elem);
   }
 
-  auto count_up_f = [](KListElem* elem, ...) -> void {
+  auto count_up_f = [](KListElem *elem, ...) -> void {
     va_list args;
     va_start(args, elem);
-    uint32_t *p_count = va_arg(args, uint32_t*);
+    uint32_t *p_count = va_arg(args, uint32_t *);
     (*p_count)++;
     va_end(args);
   };
   uint32_t num_of_elements = 0;
   KLIST_HEAD_FOREACH(p_head, count_up_f, &num_of_elements);
-  ASSERT_EQ(sizeof(bufs)/sizeof(bufs[0]), num_of_elements );
+  ASSERT_EQ(sizeof(bufs) / sizeof(bufs[0]), num_of_elements);
 
   uint32_t i = 1;
-  while(p_head) {
+  while (p_head) {
     TestObj *elem = 0;
     KLIST_HEAD_POP(p_head, elem);
     ASSERT_EQ(10 + (num_of_elements - i), elem->val);
@@ -68,4 +68,4 @@ TEST_F(KlistTest, MustInsert) {
   }
 }
 
-}
+} // namespace tests

--- a/tests/mem_ring_buffer_test.cpp
+++ b/tests/mem_ring_buffer_test.cpp
@@ -25,38 +25,33 @@
 #include <cutils/ring_buffer.h>
 #include <gtest/gtest.h>
 
-#define TEST_BUFFER_SIZE              (50)
+#define TEST_BUFFER_SIZE (50)
 MEM_RING_BUFFER_STORE_DECL(test_buffer, TEST_BUFFER_SIZE);
 MEM_RING_BUFFER_STORE_DEF(test_buffer);
 namespace tests {
 class MemRingBufferObj : public ::testing::Test {
 protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     ring_buffer_create_params_t params;
     MEM_RING_BUFFER_CREATE_PARAMS_INIT(params, test_buffer);
     this->ring_buffer = create_ring_buffer(&params);
   }
 
-  void TearDown() override
-  {
-    ring_buffer_release(this->ring_buffer);
-  }
+  void TearDown() override { ring_buffer_release(this->ring_buffer); }
+
 protected:
   ring_buffer_ref ring_buffer;
 };
 
-TEST_F(MemRingBufferObj, ShouldBeCreatedWithProperSize)
-{
+TEST_F(MemRingBufferObj, ShouldBeCreatedWithProperSize) {
   ASSERT_EQ(TEST_BUFFER_SIZE, ring_buffer_get_size(this->ring_buffer));
 }
 
-TEST_F(MemRingBufferObj, StoresElementsInOrderOfInsertion)
-{
+TEST_F(MemRingBufferObj, StoresElementsInOrderOfInsertion) {
   uint8_t buf[20] = {0};
   uint8_t buf2[20] = {0};
-  for(uint32_t i = 0; i < GetArraySize(buf); i++) {
-    buf[i] = i+1;
+  for (uint32_t i = 0; i < GetArraySize(buf); i++) {
+    buf[i] = i + 1;
   }
   ASSERT_EQ(sizeof(buf), ring_buffer_write_data(this->ring_buffer, buf, sizeof(buf)));
   auto bytes_to_read = ring_buffer_get_bytes_available_for_read(this->ring_buffer);
@@ -66,22 +61,21 @@ TEST_F(MemRingBufferObj, StoresElementsInOrderOfInsertion)
   ASSERT_EQ(bytes_to_read, range.total_bytes);
   copy_ring_data_to_buffer(&range, buf2);
   ASSERT_EQ(0, memcmp(buf, buf2, sizeof(buf)));
-
 }
-TEST_F(MemRingBufferObj, ShouldWrapAsExpected)
-{
+TEST_F(MemRingBufferObj, ShouldWrapAsExpected) {
   uint8_t buf[TEST_BUFFER_SIZE] = {0};
   uint8_t buf2[TEST_BUFFER_SIZE] = {0};
   uint8_t buf3[TEST_BUFFER_SIZE] = {0};
-  for(uint32_t i = 0 ; i < TEST_BUFFER_SIZE; i++) {
-    buf[i] = i+1;
+  for (uint32_t i = 0; i < TEST_BUFFER_SIZE; i++) {
+    buf[i] = i + 1;
     buf2[i] = TEST_BUFFER_SIZE + i + 1;
   }
   ASSERT_EQ(sizeof(buf), ring_buffer_write_data(this->ring_buffer, buf, sizeof(buf)));
   ASSERT_EQ(0, ring_buffer_get_bytes_available_for_write(this->ring_buffer));
   uint32_t bytes_to_overwrite = 10;
   ring_buffer_clear_data(this->ring_buffer, bytes_to_overwrite);
-  ASSERT_EQ(bytes_to_overwrite, ring_buffer_write_data(this->ring_buffer, buf2, bytes_to_overwrite));
+  ASSERT_EQ(bytes_to_overwrite,
+            ring_buffer_write_data(this->ring_buffer, buf2, bytes_to_overwrite));
   auto bytes_to_read = ring_buffer_get_bytes_available_for_read(this->ring_buffer);
   ASSERT_EQ(TEST_BUFFER_SIZE, bytes_to_read);
 
@@ -93,5 +87,4 @@ TEST_F(MemRingBufferObj, ShouldWrapAsExpected)
   ASSERT_EQ(0, memcmp(buf2, &buf3[TEST_BUFFER_SIZE - bytes_to_overwrite], bytes_to_overwrite));
 }
 
-};
-
+}; // namespace tests

--- a/tests/notifier_tests.c
+++ b/tests/notifier_tests.c
@@ -22,54 +22,46 @@
  * THE SOFTWARE.
  */
 
-#include <embUnit/embUnit.h>
 #include <cutils/notifier.h>
 #include <cutils/task.h>
+#include <embUnit/embUnit.h>
 #include <malloc.h>
 #include <stdlib.h>
 
 /**
  * @struct test_notification_t
- * This is an example of a client notification. The test client exposes a callback defined by callback_f
- * This structure is derived from the notifier_block_t
+ * This is an example of a client notification. The test client exposes a callback defined by
+ * callback_f This structure is derived from the notifier_block_t
  * @brief
  */
-typedef struct _test_notification_t
-{
+typedef struct _test_notification_t {
   notifier_block_t base;
-  void (*callback_f) (uint32_t category, uint32_t val);
+  void (*callback_f)(uint32_t category, uint32_t val);
   uint32_t posted_val;
 } test_notification_t;
 
-typedef struct _test1_data_t
-{
+typedef struct _test1_data_t {
   notifier_create_params_t create_params;
 } test1_data_t;
 
 /**
- * This creates the static storage needed to create a notifier that can have 256 categories and can have a total of
- * 256 callback registrations. The details of each callback are represented by test_notification_t
+ * This creates the static storage needed to create a notifier that can have 256 categories and can
+ * have a total of 256 callback registrations. The details of each callback are represented by
+ * test_notification_t
  */
 NOTIFIER_STORE_DECL(notifier_test1, 256, 256, sizeof(test_notification_t));
 NOTIFIER_STORE_DEF(notifier_test1);
 
 static test1_data_t s_data;
 
-static void counting_notification_post(notifier_t * notifier, uint32_t max_cat, uint32_t max_not);
-static void setUp(void)
-{
-  srand(task_get_ticks());
-}
+static void counting_notification_post(notifier_t *notifier, uint32_t max_cat, uint32_t max_not);
+static void setUp(void) { srand(task_get_ticks()); }
 
-static void tearDown(void)
-{
-  notifier_deinit(s_data.create_params.notifier);
-}
+static void tearDown(void) { notifier_deinit(s_data.create_params.notifier); }
 
 static inline uint32_t get_count_of_posts_for_category(uint32_t category,
                                                        uint32_t max_posts,
-                                                       test_notification_t ** posted_array)
-{
+                                                       test_notification_t **posted_array) {
   uint32_t retval = 0;
 
   for (uint32_t i = 0; i < max_posts; i++) {
@@ -78,35 +70,28 @@ static inline uint32_t get_count_of_posts_for_category(uint32_t category,
   return retval;
 }
 
-typedef struct
-{
+typedef struct {
   uint32_t count;
   uint32_t num_of_regs;
 } posted_counts_t;
 
-static void test_notifier_callback(notifier_block_t * block, uint32_t category, void *notif_data)
-{
-  posted_counts_t *count_array = (posted_counts_t *) notif_data;
+static void test_notifier_callback(notifier_block_t *block, uint32_t category, void *notif_data) {
+  posted_counts_t *count_array = (posted_counts_t *)notif_data;
 
   count_array[category].count++;
 }
 
-static void can_post_notification(void)
-{
-  NOTIFIER_STORE_CREATE_PARAMS_INIT(s_data.create_params,
-                                    notifier_test1,
-                                    test_notifier_callback,
-                                    "test_notif",
-                                    true);
+static void can_post_notification(void) {
+  NOTIFIER_STORE_CREATE_PARAMS_INIT(
+      s_data.create_params, notifier_test1, test_notifier_callback, "test_notif", true);
   TEST_ASSERT(notifier_init(&s_data.create_params));
-  TEST_ASSERT(s_data.create_params.notifier );
+  TEST_ASSERT(s_data.create_params.notifier);
   counting_notification_post(s_data.create_params.notifier,
                              s_data.create_params.total_categories,
                              s_data.create_params.max_registrations);
 }
 
-static void counting_notification_post(notifier_t * notifier, uint32_t max_cat, uint32_t max_not)
-{
+static void counting_notification_post(notifier_t *notifier, uint32_t max_cat, uint32_t max_not) {
   posted_counts_t *count_array = malloc(sizeof(posted_counts_t) * max_cat);
   uint32_t number_of_posts = rand() % max_not;
   test_notification_t **posted_array = malloc(sizeof(test_notification_t *) * number_of_posts);
@@ -117,7 +102,8 @@ static void counting_notification_post(notifier_t * notifier, uint32_t max_cat, 
   memset(posted_array, 0, sizeof(test_notification_t *) * number_of_posts);
   for (uint32_t i = 0; i < number_of_posts; i++) {
     uint32_t sample_input = rand() % max_cat;
-    test_notification_t *notif = (test_notification_t *) notifier_allocate_notification_block(notifier);
+    test_notification_t *notif =
+        (test_notification_t *)notifier_allocate_notification_block(notifier);
 
     TEST_ASSERT(notif);
     posted_array[i] = notif;
@@ -151,55 +137,41 @@ static void counting_notification_post(notifier_t * notifier, uint32_t max_cat, 
   free(posted_array);
 }
 
-typedef struct
-{
+typedef struct {
   notifier_create_params_t params;
 } static_notif_test_data_t;
-static static_notif_test_data_t s_test2 = { 0 };
+static static_notif_test_data_t s_test2 = {0};
 
 NOTIFIER_STORE_DECL(test_notif_store, 10, 64, sizeof(test_notification_t));
 NOTIFIER_STORE_DEF(test_notif_store);
 
-static void setup2(void)
-{
+static void setup2(void) {}
 
-}
+static void teardown2(void) { notifier_deinit(s_test2.params.notifier); }
 
-static void teardown2(void)
-{
-  notifier_deinit(s_test2.params.notifier);
-}
-
-static void static_notifier_store_can_post(void)
-{
-  NOTIFIER_STORE_CREATE_PARAMS_INIT(s_test2.params, test_notif_store,
-                                                     test_notifier_callback, "TestNotif2", true);
+static void static_notifier_store_can_post(void) {
+  NOTIFIER_STORE_CREATE_PARAMS_INIT(
+      s_test2.params, test_notif_store, test_notifier_callback, "TestNotif2", true);
   TEST_ASSERT_MESSAGE(notifier_init(&s_test2.params), "Could not create static notifier");
   counting_notification_post(s_test2.params.notifier,
                              GetArraySize(NOTIFIER_STORE(test_notif_store).notifierArray),
                              s_test2.params.notifier->p_pool->num_of_elements);
 }
 
-TestRef notifier_get_tests(void)
-{
-  EMB_UNIT_TESTFIXTURES(fixture) {
-    new_TestFixture("Can post notifications", can_post_notification)
-  };
+TestRef notifier_get_tests(void) {
+  EMB_UNIT_TESTFIXTURES(fixture){new_TestFixture("Can post notifications", can_post_notification)};
   EMB_UNIT_TESTCALLER(notifier_tests, "Notifier Tests", setUp, tearDown, fixture);
-  return (TestRef) & notifier_tests;
+  return (TestRef)&notifier_tests;
 }
 
-TestRef notifier_static_store_get_tests(void)
-{
-  EMB_UNIT_TESTFIXTURES(fixture) {
-    new_TestFixture("Can post notifications to Notifer with static store", static_notifier_store_can_post)
-  };
+TestRef notifier_static_store_get_tests(void) {
+  EMB_UNIT_TESTFIXTURES(fixture){new_TestFixture(
+      "Can post notifications to Notifer with static store", static_notifier_store_can_post)};
   EMB_UNIT_TESTCALLER(notifier_tests, "Notifier Static Store Tests", setup2, teardown2, fixture);
-  return (TestRef) & notifier_tests;
+  return (TestRef)&notifier_tests;
 }
 
-int main()
-{
+int main() {
   TestRunner_start();
   {
     TestRunner_runTest(notifier_get_tests());

--- a/tests/os_test.cpp
+++ b/tests/os_test.cpp
@@ -22,26 +22,19 @@
  * THE SOFTWARE.
  */
 
-#include <gtest/gtest.h>
-#include <cutils/mutex.h>
 #include <cutils/event_flag.h>
+#include <cutils/mutex.h>
 #include <cutils/task.h>
+#include <gtest/gtest.h>
 
-namespace tests
-{
-class MutexTest : public ::testing::Test
-{
+namespace tests {
+class MutexTest : public ::testing::Test {
 protected:
-  MutexTest() : m_mtx{0}
-  {}
+  MutexTest() : m_mtx{0} {}
 
-  void SetUp() override
-  {
-    mutex_new(&m_mtx);
-  }
+  void SetUp() override { mutex_new(&m_mtx); }
 
-  void TearDown() override
-  {
+  void TearDown() override {
     mutex_free(&m_mtx);
     Test::TearDown();
   }
@@ -50,15 +43,13 @@ protected:
   mutex_t m_mtx;
 };
 
-TEST_F(MutexTest, MutexApiShouldReturnValidData)
-{
+TEST_F(MutexTest, MutexApiShouldReturnValidData) {
   ASSERT_TRUE(mutex_unlock(&m_mtx));
   ASSERT_TRUE(mutex_lock(&m_mtx, 0));
   ASSERT_TRUE(mutex_unlock(&m_mtx));
 }
 
-TEST_F(MutexTest, MutexTimedAPIShouldWorkAsExpected)
-{
+TEST_F(MutexTest, MutexTimedAPIShouldWorkAsExpected) {
   ASSERT_TRUE(mutex_lock(&m_mtx, 0));
   ASSERT_TRUE(!mutex_lock(&m_mtx, 1000));
   ASSERT_TRUE(mutex_unlock(&m_mtx));
@@ -66,32 +57,24 @@ TEST_F(MutexTest, MutexTimedAPIShouldWorkAsExpected)
 
 class EventFlagTest : public ::testing::Test {
 public:
-  EventFlagTest() : m_evt{0}
-  {}
-protected:
-  void SetUp() override
-  {
-    event_flag_new(&m_evt);
-  }
+  EventFlagTest() : m_evt{0} {}
 
-  void TearDown() override
-  {
-    event_flag_free(&m_evt);
-  }
+protected:
+  void SetUp() override { event_flag_new(&m_evt); }
+
+  void TearDown() override { event_flag_free(&m_evt); }
 
 protected:
   event_flag_t m_evt;
-
 };
 
 TEST_F(EventFlagTest, EventFlagAPI) {
-  ASSERT_FALSE(event_flag_wait(&m_evt, 0x1, WAIT_OR_CLEAR, nullptr, NO_SLEEP ));
+  ASSERT_FALSE(event_flag_wait(&m_evt, 0x1, WAIT_OR_CLEAR, nullptr, NO_SLEEP));
 }
-TEST_F(EventFlagTest, EventFlagAnswerForCorrectBits)
-{
+TEST_F(EventFlagTest, EventFlagAnswerForCorrectBits) {
   uint32_t actual_flags = 0;
   ASSERT_TRUE(!event_flag_wait(&m_evt, 0x3, WAIT_OR_CLEAR, &actual_flags, 0));
-  ASSERT_EQ(0,actual_flags);
+  ASSERT_EQ(0, actual_flags);
   ASSERT_TRUE(event_flag_send(&m_evt, 0x1));
   ASSERT_TRUE(event_flag_wait(&m_evt, 0x3, WAIT_OR, &actual_flags, 0));
   ASSERT_EQ(1, actual_flags);
@@ -107,36 +90,32 @@ TEST_F(EventFlagTest, EventFlagAnswerForCorrectBits)
   ASSERT_FALSE(event_flag_wait(&m_evt, 0x3, WAIT_OR, &actual_flags, 0));
 }
 
-TASK_STATIC_STORE_DECL(test_task,16 * 1024);
+TASK_STATIC_STORE_DECL(test_task, 16 * 1024);
 TASK_STATIC_STORE_DEF(test_task);
 
 class TaskTest : public ::testing::Test {
 public:
-  TaskTest() : m_flag{0}, m_value{0}, m_mutex{0}, m_task{0}
-  {}
+  TaskTest() : m_flag{0}, m_value{0}, m_mutex{0}, m_task{0} {}
+
 protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     m_value = 0;
     event_flag_new(&m_flag);
     mutex_new(&m_mutex);
   }
 
-  void TearDown() override
-  {
+  void TearDown() override {
     event_flag_free(&m_flag);
     mutex_free(&m_mutex);
   }
   static void test_thread_function(void *arg);
   static void prempt_test_thread_hi(void *arg);
   static void prempt_test_thread_mid(void *arg);
+
 public:
-  void set_value(uint32_t value) {
-    m_value = value;
-  }
-  uint32_t get_value() {
-    return m_value;
-  }
+  void set_value(uint32_t value) { m_value = value; }
+  uint32_t get_value() { return m_value; }
+
 protected:
   task_t m_task;
   event_flag_t m_flag;
@@ -144,17 +123,19 @@ protected:
   uint32_t m_value;
 };
 
-void TaskTest::test_thread_function(void *arg)
-{
-  auto* p_task = (TaskTest*) arg;
+void TaskTest::test_thread_function(void *arg) {
+  auto *p_task = (TaskTest *)arg;
   p_task->set_value(1);
 }
 
-TEST_F(TaskTest, TaskApiTest)
-{
+TEST_F(TaskTest, TaskApiTest) {
   task_create_params_t params;
-  TASK_STATIC_INIT_CREATE_PARAMS(params, test_task, (char*)"Test Thread", CUTILS_TASK_PRIORITY_MEDIUM, test_thread_function,
-                                 (void*)this);
+  TASK_STATIC_INIT_CREATE_PARAMS(params,
+                                 test_task,
+                                 (char *)"Test Thread",
+                                 CUTILS_TASK_PRIORITY_MEDIUM,
+                                 test_thread_function,
+                                 (void *)this);
   task_t *p_task = task_new_static(&params);
   ASSERT_TRUE(p_task);
   task_start(p_task);
@@ -163,20 +144,18 @@ TEST_F(TaskTest, TaskApiTest)
   task_destroy_static(p_task);
 }
 
-void TaskTest::prempt_test_thread_hi(void *arg)
-{
-  auto * p_test = (TaskTest*)arg;
+void TaskTest::prempt_test_thread_hi(void *arg) {
+  auto *p_test = (TaskTest *)arg;
   mutex_lock(&p_test->m_mutex, WAIT_FOREVER);
-  p_test->m_value= 20;
+  p_test->m_value = 20;
   mutex_unlock(&p_test->m_mutex);
   event_flag_send(&p_test->m_flag, 0x2);
 }
 
-void TaskTest::prempt_test_thread_mid(void *arg)
-{
+void TaskTest::prempt_test_thread_mid(void *arg) {
   uint32_t val = 0;
   bool keepRunning = true;
-  auto *p_test = (TaskTest*)arg;
+  auto *p_test = (TaskTest *)arg;
 
   while (keepRunning) {
     mutex_lock(&p_test->m_mutex, WAIT_FOREVER);
@@ -194,24 +173,22 @@ TASK_STATIC_STORE_DECL(thread_hi, 2048);
 static TASK_STATIC_STORE_DEF(thread_mid);
 static TASK_STATIC_STORE_DEF(thread_hi);
 
-TEST_F(TaskTest, BasicPremption)
-{
+TEST_F(TaskTest, BasicPremption) {
   task_t *p_task_mid = 0;
   task_t *p_task_hi = 0;
   task_create_params_t params = {0};
   TASK_STATIC_INIT_CREATE_PARAMS(params,
                                  thread_mid,
-                                 (char*)"ThreadMid",
+                                 (char *)"ThreadMid",
                                  CUTILS_TASK_PRIORITY_MEDIUM,
                                  TaskTest::prempt_test_thread_mid,
                                  this);
   p_task_mid = task_new_static(&params);
   ASSERT_TRUE(p_task_mid);
 
-
   TASK_STATIC_INIT_CREATE_PARAMS(params,
                                  thread_hi,
-                                 (char*)"ThreadHi",
+                                 (char *)"ThreadHi",
                                  CUTILS_TASK_PRIORITY_MID_HIGH,
                                  prempt_test_thread_hi,
                                  this);
@@ -226,4 +203,4 @@ TEST_F(TaskTest, BasicPremption)
   task_destroy_static(p_task_mid);
   task_destroy_static(p_task_hi);
 }
-}
+} // namespace tests

--- a/tests/pool_tests.c
+++ b/tests/pool_tests.c
@@ -22,23 +22,22 @@
  * THE SOFTWARE.
  */
 
-#include <cutils/pool.h>
-#include <cutils/task.h>
 #include <cutils/klist.h>
-#include <cutils/signal.h>
-#include <embUnit/embUnit.h>
 #include <cutils/logger.h>
+#include <cutils/pool.h>
+#include <cutils/signal.h>
+#include <cutils/task.h>
+#include <embUnit/embUnit.h>
 #include <stdlib.h>
 
-#define _pool_test1_ALIGN       ( 64 )
-#define _pool_test1_QUEUE_SIZE ( 4 )
-#define _pool_test2_ALIGN       ( 32 )
-#define _pool_test2_QUEUE_SIZE ( 8 )
-#define _pool_test3_ALIGN       ( 1 )
-#define _pool_test3_QUEUE_SIZE ( 16 )
+#define _pool_test1_ALIGN (64)
+#define _pool_test1_QUEUE_SIZE (4)
+#define _pool_test2_ALIGN (32)
+#define _pool_test2_QUEUE_SIZE (8)
+#define _pool_test3_ALIGN (1)
+#define _pool_test3_QUEUE_SIZE (16)
 
-typedef struct _test_allocation_t
-{
+typedef struct _test_allocation_t {
   KListElem elem;
   uint32_t dummy;
 } test_allocation_t;
@@ -50,65 +49,63 @@ POOL_STORE_DEF(pool_test1);
 POOL_STORE_DEF(pool_test2);
 POOL_STORE_DEF(pool_test3);
 
-//The only reason why this actually cylces through all the memory entries
-//is because the pool uses a queue (FIFO) to maintain the free buffers.
-#define TEST_A_POOL_WITH_CREATE_PARAMS(name)\
-{\
-  pool_create_params_t params;\
-  POOL_CREATE_INIT( params, name );\
-  pool_t* p_pool = pool_create( &params );\
-  TEST_ASSERT_MESSAGE( p_pool != 0, "Couldn't create Static Pool" );\
-  TEST_ASSERT_EQUAL_INT( _##name##_QUEUE_SIZE, p_pool->num_of_elements );\
-  KListHead *head = NULL;\
-  for( size_t i = 0; i < p_pool->num_of_elements; i++ ){ \
-    void* alloc = pool_alloc( p_pool );\
-    TEST_ASSERT_MESSAGE(alloc, "Couldn't allocate from pool" );\
-    TEST_ASSERT_MESSAGE(((size_t)alloc & (_##name##_ALIGN - 1)) == 0, "Allocation not aligned");\
-    memset(alloc, 0, p_pool->element_size);\
-    pool_header_t* p_header = (pool_header_t*)((uint8_t*)alloc - p_pool->offset_data_from_header);\
-    TEST_ASSERT_MESSAGE(POOL_ELEMENT_HEADER_SANITY == p_header->sanity, "Header sanity is not valid");\
-    TEST_ASSERT_MESSAGE(POOL_ELEMENT_TRAILER_SANITY == *((uint32_t*)(alloc + p_pool->element_size)), "Footer sanity does not match"  );\
-    KLIST_HEAD_PREPEND(head, alloc);\
-  }\
-  while(head) {\
-    void* alloc = 0;\
-    KLIST_HEAD_POP(head, alloc);\
-    TEST_ASSERT(alloc);\
-    pool_free(p_pool, alloc);\
-  }\
-  pool_destroy(p_pool);\
-}
+// The only reason why this actually cylces through all the memory entries
+// is because the pool uses a queue (FIFO) to maintain the free buffers.
+#define TEST_A_POOL_WITH_CREATE_PARAMS(name)                                                       \
+  {                                                                                                \
+    pool_create_params_t params;                                                                   \
+    POOL_CREATE_INIT(params, name);                                                                \
+    pool_t *p_pool = pool_create(&params);                                                         \
+    TEST_ASSERT_MESSAGE(p_pool != 0, "Couldn't create Static Pool");                               \
+    TEST_ASSERT_EQUAL_INT(_##name##_QUEUE_SIZE, p_pool->num_of_elements);                          \
+    KListHead *head = NULL;                                                                        \
+    for (size_t i = 0; i < p_pool->num_of_elements; i++) {                                         \
+      void *alloc = pool_alloc(p_pool);                                                            \
+      TEST_ASSERT_MESSAGE(alloc, "Couldn't allocate from pool");                                   \
+      TEST_ASSERT_MESSAGE(((size_t)alloc & (_##name##_ALIGN - 1)) == 0, "Allocation not aligned"); \
+      memset(alloc, 0, p_pool->element_size);                                                      \
+      pool_header_t *p_header =                                                                    \
+          (pool_header_t *)((uint8_t *)alloc - p_pool->offset_data_from_header);                   \
+      TEST_ASSERT_MESSAGE(POOL_ELEMENT_HEADER_SANITY == p_header->sanity,                          \
+                          "Header sanity is not valid");                                           \
+      TEST_ASSERT_MESSAGE(POOL_ELEMENT_TRAILER_SANITY ==                                           \
+                              *((uint32_t *)(alloc + p_pool->element_size)),                       \
+                          "Footer sanity does not match");                                         \
+      KLIST_HEAD_PREPEND(head, alloc);                                                             \
+    }                                                                                              \
+    while (head) {                                                                                 \
+      void *alloc = 0;                                                                             \
+      KLIST_HEAD_POP(head, alloc);                                                                 \
+      TEST_ASSERT(alloc);                                                                          \
+      pool_free(p_pool, alloc);                                                                    \
+    }                                                                                              \
+    pool_destroy(p_pool);                                                                          \
+  }
 
-static void pool_static_should_create_with_params_aligned_allocations_test1(void)
-{
+static void pool_static_should_create_with_params_aligned_allocations_test1(void) {
   TEST_A_POOL_WITH_CREATE_PARAMS(pool_test1);
 }
 
-static void pool_static_should_create_with_params_aligned_allocations_test2(void)
-{
+static void pool_static_should_create_with_params_aligned_allocations_test2(void) {
   TEST_A_POOL_WITH_CREATE_PARAMS(pool_test2);
 }
 
-static void pool_static_should_create_with_params_aligned_allocations_test3(void)
-{
+static void pool_static_should_create_with_params_aligned_allocations_test3(void) {
   TEST_A_POOL_WITH_CREATE_PARAMS(pool_test3);
 }
 
-typedef struct _ref_count_test_t
-{
+typedef struct _ref_count_test_t {
   uint32_t total_count;
 } ref_count_test_t;
 
 static ref_count_test_t s_test_data = {0};
 
-static void test_destructor_f(void *mem, void *private)
-{
+static void test_destructor_f(void *mem, void *private) {
   TEST_ASSERT_MESSAGE(s_test_data.total_count == 0, "Destructor called before References removed");
-  s_test_data.total_count = (uint32_t) -1;
+  s_test_data.total_count = (uint32_t)-1;
 }
 
-static void pool_test_ref_count(void)
-{
+static void pool_test_ref_count(void) {
   pool_create_params_t params;
   POOL_CREATE_INIT(params, pool_test3);
   pool_t *p_pool = pool_create(&params);
@@ -118,12 +115,13 @@ static void pool_test_ref_count(void)
   for (uint32_t i = 0; i < p_pool->num_of_elements; i++) {
     void *alloc = pool_alloc(p_pool);
     TEST_ASSERT_MESSAGE(alloc, "Couldn't allocate from pool");
-    TEST_ASSERT_MESSAGE(((size_t) alloc & (_pool_test3_ALIGN - 1)) == 0, "Allocation not aligned");
-    pool_header_t *p_header = (pool_header_t *) ((uint8_t *) alloc -
-                                                 p_pool->offset_data_from_header);
-    TEST_ASSERT_MESSAGE(POOL_ELEMENT_HEADER_SANITY == p_header->sanity, "Header sanity is not valid");\
-    TEST_ASSERT_MESSAGE(POOL_ELEMENT_TRAILER_SANITY == *((uint32_t *) (alloc + p_pool->element_size)),
-                        "Footer sanity does not match");\
+    TEST_ASSERT_MESSAGE(((size_t)alloc & (_pool_test3_ALIGN - 1)) == 0, "Allocation not aligned");
+    pool_header_t *p_header = (pool_header_t *)((uint8_t *)alloc - p_pool->offset_data_from_header);
+    TEST_ASSERT_MESSAGE(POOL_ELEMENT_HEADER_SANITY == p_header->sanity,
+                        "Header sanity is not valid");
+    TEST_ASSERT_MESSAGE(POOL_ELEMENT_TRAILER_SANITY ==
+                            *((uint32_t *)(alloc + p_pool->element_size)),
+                        "Footer sanity does not match");
     memset(alloc, 0, p_pool->element_size);
     s_test_data.total_count++;
     TEST_ASSERT_MESSAGE(atomic_load(&p_header->retain_count) == 1, "Expected a retain count of 1");
@@ -139,74 +137,71 @@ static void pool_test_ref_count(void)
     count++;
     KLIST_HEAD_POP(head, alloc);
     TEST_ASSERT_NOT_NULL(alloc);
-    pool_header_t *p_header = (pool_header_t *) ((uint8_t *) alloc -
-                                                 p_pool->offset_data_from_header);
-    TEST_ASSERT_MESSAGE(POOL_ELEMENT_HEADER_SANITY == p_header->sanity, "Header sanity is not valid");\
-    TEST_ASSERT_MESSAGE(POOL_ELEMENT_TRAILER_SANITY == *((uint32_t *) (alloc + p_pool->element_size)),
-                        "Footer sanity does not match");\
+    pool_header_t *p_header = (pool_header_t *)((uint8_t *)alloc - p_pool->offset_data_from_header);
+    TEST_ASSERT_MESSAGE(POOL_ELEMENT_HEADER_SANITY == p_header->sanity,
+                        "Header sanity is not valid");
+    TEST_ASSERT_MESSAGE(POOL_ELEMENT_TRAILER_SANITY ==
+                            *((uint32_t *)(alloc + p_pool->element_size)),
+                        "Footer sanity does not match");
     pool_free(p_pool, alloc);
-    TEST_ASSERT_MESSAGE(atomic_load(&p_header->retain_count) == 1, "Expected retain count to drop to 1");
+    TEST_ASSERT_MESSAGE(atomic_load(&p_header->retain_count) == 1,
+                        "Expected retain count to drop to 1");
     s_test_data.total_count = 0;
     pool_free(p_pool, alloc);
-    TEST_ASSERT_MESSAGE(atomic_load(&p_header->retain_count) == 0, "Expected retain count to drop to 0");
+    TEST_ASSERT_MESSAGE(atomic_load(&p_header->retain_count) == 0,
+                        "Expected retain count to drop to 0");
   }
   TEST_ASSERT_EQUAL_INT(p_pool->num_of_elements, count);
-  TEST_ASSERT_MESSAGE(s_test_data.total_count == (uint32_t) -1, "Unexpected final value. Destructor not called");
+  TEST_ASSERT_MESSAGE(s_test_data.total_count == (uint32_t)-1,
+                      "Unexpected final value. Destructor not called");
   pool_destroy(p_pool);
 }
 
-static void setUp(void)
-{
-  memset(&s_test_data, 0, sizeof(s_test_data));
-}
+static void setUp(void) { memset(&s_test_data, 0, sizeof(s_test_data)); }
 
-static void tearDown(void)
-{}
+static void tearDown(void) {}
 
 #if 1
 /**
- * @brief The following unit test attempts to test the reference counting of the pool across a number of threads
- * It creates a high priority launcher thread whose job is to create a large number of test threads of lower priority
- * than the launcher and then exit. The Main test will create a test pool, create an allocation from the test pool.
- * It will then start the launcher and wait for it to complete. It then waits for all test threads to complete and
- * finally deallocates the allocation and confirms that the destructor is called.
+ * @brief The following unit test attempts to test the reference counting of the pool across a
+ * number of threads It creates a high priority launcher thread whose job is to create a large
+ * number of test threads of lower priority than the launcher and then exit. The Main test will
+ * create a test pool, create an allocation from the test pool. It will then start the launcher and
+ * wait for it to complete. It then waits for all test threads to complete and finally deallocates
+ * the allocation and confirms that the destructor is called.
  */
-#define NUM_OF_THREADS      (1000)
+#define NUM_OF_THREADS (1000)
 #define MAX_TEST_TASK_SLEEP (10)
 
 TASK_STATIC_STORE_DECL(launcher_task, 4096);
 TASK_STATIC_STORE_DECL(retainer_task, 1024);
 
-typedef enum
-{
+typedef enum {
   POOL_RETAIN_TEST_RUNNING,
   POOL_RETAIN_TEST_FAIL_ALLOC,
   POOL_RETAIN_TEST_FAIL_CREATE,
   POOL_RETAIN_TEST_SUCCESS
 } pool_retain_test_results_e;
 
-typedef struct
-{
+typedef struct {
   pool_t *p_pool;
   void *alloc;
-  TASK_STATIC_STORE_T(launcher_task) *p_launcher_store;
-  TASK_STATIC_STORE_T(retainer_task) *retainerStores[NUM_OF_THREADS];
+  TASK_STATIC_STORE_T(launcher_task) * p_launcher_store;
+  TASK_STATIC_STORE_T(retainer_task) * retainerStores[NUM_OF_THREADS];
   signal_t launcher_exit;
   pool_retain_test_results_e result;
   atomic_uint complete_count;
 } pool_retain_test_data_t;
 static pool_retain_test_data_t s_test_data2 = {0};
 
-static void cleanup_launcher(pool_retain_test_data_t *p_test_data)
-{
+static void cleanup_launcher(pool_retain_test_data_t *p_test_data) {
   task_t *p_launcher_task = &p_test_data->p_launcher_store->tsk;
   task_destroy_static(p_launcher_task);
   free(p_test_data->p_launcher_store);
   p_test_data->p_launcher_store = 0;
 }
 
-static void cleanup_retainers(pool_retain_test_data_t *p_test_data)
-{
+static void cleanup_retainers(pool_retain_test_data_t *p_test_data) {
   for (uint32_t i = 0; i < NUM_OF_THREADS; i++) {
     if (p_test_data->retainerStores[i]) {
       task_t *p_task = &p_test_data->retainerStores[i]->tsk;
@@ -217,32 +212,29 @@ static void cleanup_retainers(pool_retain_test_data_t *p_test_data)
   }
 }
 
-static void pool_retainer_action(void *ctx)
-{
-  pool_retain_test_data_t *p_test_data = (pool_retain_test_data_t *) ctx;
+static void pool_retainer_action(void *ctx) {
+  pool_retain_test_data_t *p_test_data = (pool_retain_test_data_t *)ctx;
   pool_retain(p_test_data->p_pool, p_test_data->alloc);
-  uint32_t timeout = (uint32_t) rand() % MAX_TEST_TASK_SLEEP;
+  uint32_t timeout = (uint32_t)rand() % MAX_TEST_TASK_SLEEP;
   task_sleep(timeout);
   pool_free(p_test_data->p_pool, p_test_data->alloc);
   atomic_fetch_add_explicit(&p_test_data->complete_count, 1, memory_order_relaxed);
 }
 
-static void launcher_action(void *ctx)
-{
-  pool_retain_test_data_t *p_test_data = (pool_retain_test_data_t *) ctx;
+static void launcher_action(void *ctx) {
+  pool_retain_test_data_t *p_test_data = (pool_retain_test_data_t *)ctx;
 
   for (uint32_t i = 0; i < NUM_OF_THREADS; i++) {
     p_test_data->retainerStores[i] = malloc(sizeof(TASK_STATIC_STORE_T(retainer_task)));
     if (p_test_data->retainerStores[i]) {
-      task_create_params_t retainer_params = {
-          .task = &p_test_data->retainerStores[i]->tsk,
-          .stack = p_test_data->retainerStores[i]->stack,
-          .stack_size = sizeof(p_test_data->retainerStores[i]->stack),
-          .label = "RetainerTask",
-          .priority = CUTILS_TASK_PRIORITY_MID_LO,
-          .func = pool_retainer_action,
-          .ctx = p_test_data
-      };
+      task_create_params_t retainer_params = {.task = &p_test_data->retainerStores[i]->tsk,
+                                              .stack = p_test_data->retainerStores[i]->stack,
+                                              .stack_size =
+                                                  sizeof(p_test_data->retainerStores[i]->stack),
+                                              .label = "RetainerTask",
+                                              .priority = CUTILS_TASK_PRIORITY_MID_LO,
+                                              .func = pool_retainer_action,
+                                              .ctx = p_test_data};
       memset(retainer_params.task, 0, sizeof(task_t));
       if (!task_new_static(&retainer_params)) {
         p_test_data->result = POOL_RETAIN_TEST_FAIL_CREATE;
@@ -259,17 +251,15 @@ static void launcher_action(void *ctx)
   signal_send(&p_test_data->launcher_exit);
 }
 
-static void destructor_fn(void *mem, void *private)
-{
-  pool_retain_test_data_t *p_test_data = (pool_retain_test_data_t *) private;
+static void destructor_fn(void *mem, void *private) {
+  pool_retain_test_data_t *p_test_data = (pool_retain_test_data_t *)private;
   p_test_data->result = POOL_RETAIN_TEST_SUCCESS;
 }
 
 POOL_STORE_DECL(retain_test_pool, 1, sizeof(uint32_t), sizeof(uint32_t));
 POOL_STORE_DEF(retain_test_pool);
 
-static void pool_multi_thread_alloc_test(void)
-{
+static void pool_multi_thread_alloc_test(void) {
   task_t *launcher_task = 0;
   srand(task_get_ticks());
 
@@ -293,15 +283,14 @@ static void pool_multi_thread_alloc_test(void)
     s_test_data2.p_launcher_store = malloc(sizeof(TASK_STATIC_STORE_T(launcher_task)));
 
     if (s_test_data2.p_launcher_store) {
-      task_create_params_t launcher_params = {
-          .task = &s_test_data2.p_launcher_store->tsk,
-          .stack = s_test_data2.p_launcher_store->stack,
-          .stack_size = sizeof(s_test_data2.p_launcher_store->stack),
-          .priority = CUTILS_TASK_PRIORITY_HIGHEST,
-          .label = "LauncherTask",
-          .func = launcher_action,
-          .ctx = &s_test_data2
-      };
+      task_create_params_t launcher_params = {.task = &s_test_data2.p_launcher_store->tsk,
+                                              .stack = s_test_data2.p_launcher_store->stack,
+                                              .stack_size =
+                                                  sizeof(s_test_data2.p_launcher_store->stack),
+                                              .priority = CUTILS_TASK_PRIORITY_HIGHEST,
+                                              .label = "LauncherTask",
+                                              .func = launcher_action,
+                                              .ctx = &s_test_data2};
       launcher_task = task_new_static(&launcher_params);
       if (!launcher_task) {
         free(s_test_data2.p_launcher_store);
@@ -321,12 +310,12 @@ static void pool_multi_thread_alloc_test(void)
     signal_free(&s_test_data2.launcher_exit);
     TEST_ASSERT_MESSAGE(0, "Failed to allocate basic resources for test");
   }
-  //Everything was setup correctly. If anything failed in setup, the test would return above this
+  // Everything was setup correctly. If anything failed in setup, the test would return above this
 
   signal_wait(&s_test_data2.launcher_exit);
-  //Launcher exited. Perform tests
+  // Launcher exited. Perform tests
   cleanup_launcher(&s_test_data2);
-  //Check all threads are done
+  // Check all threads are done
   bool success = false;
   for (uint32_t i = 0; i < NUM_OF_THREADS; i++) {
     uint32_t count = atomic_load_explicit(&s_test_data2.complete_count, memory_order_acquire);
@@ -338,15 +327,14 @@ static void pool_multi_thread_alloc_test(void)
   }
   if (!success) {
     CLOG("Retainer Thread Failed to complete. Count = %d",
-              atomic_load_explicit(&s_test_data2.complete_count, memory_order_acquire));
+         atomic_load_explicit(&s_test_data2.complete_count, memory_order_acquire));
     cleanup_retainers(&s_test_data2);
     pool_destroy(s_test_data2.p_pool);
     signal_free(&s_test_data2.launcher_exit);
     TEST_ASSERT_MESSAGE(0, "Retain tasks failed to complete");
-
   }
   pool_set_destructor(s_test_data2.p_pool, s_test_data2.alloc, destructor_fn, &s_test_data2);
-  //Free the allocation. This should destroy it
+  // Free the allocation. This should destroy it
   pool_free(s_test_data2.p_pool, s_test_data2.alloc);
   cleanup_retainers(&s_test_data2);
   pool_destroy(s_test_data2.p_pool);
@@ -354,9 +342,8 @@ static void pool_multi_thread_alloc_test(void)
   TEST_ASSERT(s_test_data2.result == POOL_RETAIN_TEST_SUCCESS);
 }
 #endif
-TestRef pool_get_tests()
-{
-  EMB_UNIT_TESTFIXTURES(fixtures) {
+TestRef pool_get_tests() {
+  EMB_UNIT_TESTFIXTURES(fixtures){
       new_TestFixture("Pool is created with proper alignments using create params 1",
                       pool_static_should_create_with_params_aligned_allocations_test1),
       new_TestFixture("Pool is created with proper alignments using create params 2",
@@ -364,14 +351,13 @@ TestRef pool_get_tests()
       new_TestFixture("Pool is created with proper alignments using create params 3",
                       pool_static_should_create_with_params_aligned_allocations_test3),
       new_TestFixture("Pool allocations can be reference counted", pool_test_ref_count),
-      new_TestFixture("Pool allocations can be referenced counted across many threads", pool_multi_thread_alloc_test)
-  };
+      new_TestFixture("Pool allocations can be referenced counted across many threads",
+                      pool_multi_thread_alloc_test)};
   EMB_UNIT_TESTCALLER(pool_basic_test, "PoolBasicTests", setUp, tearDown, fixtures);
-  return (TestRef) &pool_basic_test;
+  return (TestRef)&pool_basic_test;
 }
 
-int main()
-{
+int main() {
   TestRunner_start();
   {
     TestRunner_runTest(pool_get_tests());

--- a/tests/queue_tests.cpp
+++ b/tests/queue_tests.cpp
@@ -9,10 +9,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,56 +22,51 @@
  * THE SOFTWARE.
  */
 
-#include <gtest/gtest.h>
-#include <cutils/kqueue.h>
-#include <cutils/ts_queue.h>
-#include <cutils/task.h>
-#include <cutils/free_list.h>
-#include <functional>
 #include <ctime>
+#include <cutils/free_list.h>
+#include <cutils/kqueue.h>
+#include <cutils/task.h>
+#include <cutils/ts_queue.h>
+#include <functional>
+#include <gtest/gtest.h>
 
 namespace tests {
 typedef struct {
-  KListElem elem; //Necessary header item
-  uint32_t data; //Client Specific data
-}free_list_test_unit_t;
+  KListElem elem; // Necessary header item
+  uint32_t data;  // Client Specific data
+} free_list_test_unit_t;
 
 FREE_LIST_STORE_DECL(test_free_list, free_list_test_unit_t, 10);
 FREE_LIST_STORE_DEF(test_free_list);
 
-class free_list_test : public  ::testing::Test {
+class free_list_test : public ::testing::Test {
 protected:
-  void SetUp() override
-  {
-    free_list_create_params_t params = { 0 };
+  void SetUp() override {
+    free_list_create_params_t params = {0};
     FREE_LIST_STORE_CREATE_PARAMS_INIT(params, test_free_list);
     m_list = free_list_init(&params);
   }
 
-  void TearDown() override
-  {
-  }
+  void TearDown() override {}
   free_list_t *m_list;
 };
 
-TEST_F(free_list_test, can_create_free_list_with_appropriate_size)
-{
+TEST_F(free_list_test, can_create_free_list_with_appropriate_size) {
   ASSERT_EQ(GetArraySize(FREE_LIST_STORE(test_free_list).store), m_list->item_count);
   ASSERT_EQ(GetArraySize(FREE_LIST_STORE(test_free_list).store), m_list->current_available);
 }
-TEST_F(free_list_test, can_allocated_as_many_as_available)
-{
-  KListHead* p_head = 0;
-  KListElem* p_alloc = 0;
-  for(uint32_t i = 0; i < m_list->item_count; i++) {
-    auto item = (free_list_test_unit_t*)free_list_get(m_list);
+TEST_F(free_list_test, can_allocated_as_many_as_available) {
+  KListHead *p_head = 0;
+  KListElem *p_alloc = 0;
+  for (uint32_t i = 0; i < m_list->item_count; i++) {
+    auto item = (free_list_test_unit_t *)free_list_get(m_list);
     ASSERT_TRUE(item);
     item->data = i + 1;
     KLIST_HEAD_PREPEND(p_head, item);
   }
   ASSERT_EQ(0, m_list->current_available);
-  while(p_head) {
-    KListElem* list_item = nullptr;
+  while (p_head) {
+    KListElem *list_item = nullptr;
     KLIST_HEAD_POP(p_head, list_item);
     ASSERT_TRUE(list_item);
     free_list_put(m_list, list_item);
@@ -82,19 +77,12 @@ TEST_F(free_list_test, can_allocated_as_many_as_available)
 class kqueue_test : public ::testing::Test {
 
 protected:
-  void SetUp() override
-  {
-    kqueue_init(&m_queue);
-  }
+  void SetUp() override { kqueue_init(&m_queue); }
 
-  void TearDown() override
-  {
-    kqueue_drop_all(&m_queue);
-  }
+  void TearDown() override { kqueue_drop_all(&m_queue); }
 
 protected:
   kqueue_t m_queue;
-
 };
 
 TEST_F(kqueue_test, queue_should_return_count_of_zero_for_empty_queue) {
@@ -105,38 +93,36 @@ TEST_F(kqueue_test, queue_should_insert_and_update_count) {
   struct {
     KListElem elem;
     int val;
-  }item = { 0 };
+  } item = {0};
   kqueue_insert(&m_queue, &item.elem);
   ASSERT_EQ(1, kqueue_get_item_count(&m_queue));
 }
 
 TEST_F(kqueue_test, queue_should_dequeue_as_expected) {
-  struct
-  {
+  struct {
     KListElem elem;
     int val;
-  } item = { 0 };
+  } item = {0};
   kqueue_insert(&m_queue, &item.elem);
   auto popped_item = kqueue_dequeue(&m_queue);
   ASSERT_EQ(0, kqueue_get_item_count(&m_queue));
   ASSERT_EQ(popped_item, &item.elem);
 }
 
-TEST_F(kqueue_test, queue_should_maintain_fifo_order)
-{
+TEST_F(kqueue_test, queue_should_maintain_fifo_order) {
   struct test_item_t {
     KListElem elem;
     int val;
-  }items[10] = {0};
-  for(uint32_t i = 0; i < GetArraySize(items); i++) {
-    items[i].val = i+1;
+  } items[10] = {0};
+  for (uint32_t i = 0; i < GetArraySize(items); i++) {
+    items[i].val = i + 1;
     kqueue_insert(&m_queue, &items[i].elem);
   }
 
-  for(uint32_t i = 0; i < GetArraySize(items); i++) {
+  for (uint32_t i = 0; i < GetArraySize(items); i++) {
     auto popped_item = kqueue_dequeue(&m_queue);
     ASSERT_EQ(&items[i].elem, popped_item);
-    ASSERT_EQ(1 + i, ((test_item_t*)popped_item)->val);
+    ASSERT_EQ(1 + i, ((test_item_t *)popped_item)->val);
   }
 }
 
@@ -152,25 +138,18 @@ TS_QUEUE_STORE_DEF(ts_queue_prod_cons);
 TS_QUEUE_STORE_DECL(ts_queue_fail, 10);
 TS_QUEUE_STORE_DEF(ts_queue_fail);
 
-TEST(ts_queue_test_simple, queue_should_fail_if_size_not_power_of_2)
-{
+TEST(ts_queue_test_simple, queue_should_fail_if_size_not_power_of_2) {
   ts_queue_create_params_t params = {0};
   TS_QUEUE_STORE_CREATE_PARAMS_INIT(params, ts_queue_fail);
   ASSERT_FALSE(ts_queue_init(&params));
 }
 
-class ts_queue_test : public ::testing::Test
-{
+class ts_queue_test : public ::testing::Test {
 public:
-  enum test_error_code_e
-  {
-    Success = 0,
-    ConsumerFailed = 1,
-    ProducerFailed = 2
-  };
+  enum test_error_code_e { Success = 0, ConsumerFailed = 1, ProducerFailed = 2 };
+
 protected:
-  struct task_data_t
-  {
+  struct task_data_t {
     KListElem elem;
     uint32_t val = 0;
     std::function<void(task_data_t *)> fn;
@@ -179,8 +158,7 @@ protected:
   FREE_LIST_STORE_DECL(ts_queue_prod_cons_free_list, ts_queue_test::task_data_t, 17);
   FREE_LIST_STORE_DEF(ts_queue_prod_cons_free_list);
 
-  void SetUp() override
-  {
+  void SetUp() override {
     free_list_create_params_t free_list_params = {0};
     ts_queue_create_params_t ts_queue_params = {0};
     FREE_LIST_STORE_CREATE_PARAMS_INIT(free_list_params, ts_queue_prod_cons_free_list);
@@ -190,89 +168,70 @@ protected:
     m_queue = ts_queue_init(&ts_queue_params);
   }
 
-  void TearDown() override
-  {
+  void TearDown() override {
     stop_tasks();
     ts_queue_destroy(m_queue);
   }
 
-  void start_tasks()
-  {
+  void start_tasks() {
     task_create_params_t params = {0};
 
-    TASK_STATIC_INIT_CREATE_PARAMS(params,
-                                   ts_queue_producer,
-                                   "producer",
-                                   CUTILS_TASK_PRIORITY_MEDIUM,
-                                   prod_task,
-                                   this);
+    TASK_STATIC_INIT_CREATE_PARAMS(
+        params, ts_queue_producer, "producer", CUTILS_TASK_PRIORITY_MEDIUM, prod_task, this);
     m_prod_task = task_new_static(&params);
-    TASK_STATIC_INIT_CREATE_PARAMS(params,
-                                   ts_queue_consumer,
-                                   "consumer",
-                                   CUTILS_TASK_PRIORITY_MEDIUM,
-                                   cons_task,
-                                   this);
+    TASK_STATIC_INIT_CREATE_PARAMS(
+        params, ts_queue_consumer, "consumer", CUTILS_TASK_PRIORITY_MEDIUM, cons_task, this);
     m_cons_task = task_new_static(&params);
   }
-  void stop_tasks()
-  {
+  void stop_tasks() {
     kill_consumer();
-    if(m_prod_task) {
+    if (m_prod_task) {
       task_destroy_static(m_prod_task);
       m_prod_task = nullptr;
     }
-    if(m_cons_task) {
+    if (m_cons_task) {
       task_destroy_static(m_cons_task);
       m_cons_task = nullptr;
     }
   }
-  inline task_data_t* alloc_data()
-  {
-    auto retval = (task_data_t*) free_list_get(m_data_store);
-    if(retval) {
+  inline task_data_t *alloc_data() {
+    auto retval = (task_data_t *)free_list_get(m_data_store);
+    if (retval) {
       memset(retval, 0, sizeof(task_data_t));
     }
     return retval;
   }
-  inline void free_data(task_data_t* data)
-  {
-    if(data) {
+  inline void free_data(task_data_t *data) {
+    if (data) {
       free_list_put(m_data_store, &data->elem);
     }
   }
-  bool post_data(task_data_t *data)
-  {
+  bool post_data(task_data_t *data) {
     bool retval = false;
-    if(data) {
-      retval = ts_queue_enqueue(m_queue, (void *) data, WAIT_FOREVER);
+    if (data) {
+      retval = ts_queue_enqueue(m_queue, (void *)data, WAIT_FOREVER);
     }
     return retval;
   }
-  void kill_consumer()
-  {
+  void kill_consumer() {
     auto data = alloc_data();
-    if(data) {
+    if (data) {
       data->val = 9999;
       post_data(data);
     }
   }
-  static void prod_task(void* ctx)
-  {
-    ts_queue_test *p_test = (ts_queue_test*)ctx;
-  }
-  static void cons_task(void* ctx) {
+  static void prod_task(void *ctx) { ts_queue_test *p_test = (ts_queue_test *)ctx; }
+  static void cons_task(void *ctx) {
     void *item = 0;
-    ts_queue_test *p_test = (ts_queue_test*)ctx;
+    ts_queue_test *p_test = (ts_queue_test *)ctx;
 
-    while (ts_queue_dequeue(p_test->m_queue, &item, 2000))
-    {
-      auto test_data = (task_data_t*)item;
-      if(test_data->val == 9999) {
+    while (ts_queue_dequeue(p_test->m_queue, &item, 2000)) {
+      auto test_data = (task_data_t *)item;
+      if (test_data->val == 9999) {
         p_test->free_data(test_data);
         return;
       }
-      if(test_data->fn) {
+      if (test_data->fn) {
         test_data->fn(test_data);
       }
     }
@@ -286,13 +245,11 @@ protected:
   test_error_code_e m_error_code;
 };
 
-TEST_F(ts_queue_test, ShouldReportZeroCountForEmptyQueue)
-{
+TEST_F(ts_queue_test, ShouldReportZeroCountForEmptyQueue) {
   ASSERT_TRUE(m_queue);
   ASSERT_EQ(0, ts_queue_get_count(m_queue));
 }
-TEST_F(ts_queue_test, ShouldBlockOnEmptyQueue)
-{
+TEST_F(ts_queue_test, ShouldBlockOnEmptyQueue) {
   void *data = 0;
   auto c_start = std::clock();
 
@@ -300,11 +257,10 @@ TEST_F(ts_queue_test, ShouldBlockOnEmptyQueue)
   ASSERT_FALSE(ts_queue_dequeue(m_queue, &data, 2000));
   auto c_end = std::clock();
   auto time = c_end - c_start;
-  ASSERT_LT(999,  time);
+  ASSERT_LT(999, time);
 }
 
-TEST_F(ts_queue_test, ShouldBlockOnFullQueue)
-{
+TEST_F(ts_queue_test, ShouldBlockOnFullQueue) {
   ASSERT_TRUE(m_queue);
   for (uint32_t i = 0; i < m_queue->size; i++) {
     task_data_t *data = alloc_data();
@@ -321,18 +277,13 @@ TEST_F(ts_queue_test, ShouldBlockOnFullQueue)
   auto time = c_end - c_start;
   ASSERT_LT(999, time);
 }
-TEST_F(ts_queue_test, ProducerConsumerShouldRun)
-{
+TEST_F(ts_queue_test, ProducerConsumerShouldRun) {
   ASSERT_TRUE(m_queue);
   start_tasks();
-  task_data_t data = { .val = 0, .fn = [](task_data_t* p_data) {
-    p_data->val = 10;
-  }};
+  task_data_t data = {.val = 0, .fn = [](task_data_t *p_data) { p_data->val = 10; }};
   ASSERT_TRUE(ts_queue_enqueue(m_queue, &data, 2000));
   stop_tasks();
   ASSERT_EQ(10, data.val);
 }
 
-}
-
-
+} // namespace tests

--- a/tests/state_event_loop_tests.c
+++ b/tests/state_event_loop_tests.c
@@ -22,33 +22,26 @@
  * THE SOFTWARE.
  */
 
-#include <embUnit/embUnit.h>
 #include <cutils/state_event_loop.h>
+#include <embUnit/embUnit.h>
 #include <stdlib.h>
 
-#define TEST_MAX_STATES                 ( 20 )
-#define TEST_QUEUE_SIZE                 ( 64 )
-#define TEST_MAX_REGISTRATIONS          ( 64 )
-#define TEST_FLAG_PRIVATE_DATA_VALID    (1U << 0U)
-#define TEST_FLAG_PRIVATE_DATA_INVALID  (1U << 1U)
+#define TEST_MAX_STATES (20)
+#define TEST_QUEUE_SIZE (64)
+#define TEST_MAX_REGISTRATIONS (64)
+#define TEST_FLAG_PRIVATE_DATA_VALID (1U << 0U)
+#define TEST_FLAG_PRIVATE_DATA_INVALID (1U << 1U)
 
-#define  PRINT_FIELD( x, fmt )    CLOG( #x " = %" #fmt, x )
+#define PRINT_FIELD(x, fmt) CLOG(#x " = %" #fmt, x)
 
-typedef enum
-{
-  TRANSITION_EVENT,
-  NO_TRANSITION_EVENT,
-  TEST_MAX_EVENT_ID
-} tests_event_e;
+typedef enum { TRANSITION_EVENT, NO_TRANSITION_EVENT, TEST_MAX_EVENT_ID } tests_event_e;
 
-typedef struct
-{
+typedef struct {
   event_t base;
   uint32_t next_state;
 } test_event_t;
 
-typedef struct
-{
+typedef struct {
   state_t base;
   uint32_t exit_state;
 } test_state_t;
@@ -56,13 +49,11 @@ typedef struct
 /**
  * Define your own callback for notifications
  */
-typedef struct
-{
+typedef struct {
   notifier_block_t base;
 } test_registration_t;
 
-typedef struct
-{
+typedef struct {
   state_t states[TEST_MAX_STATES];
   state_event_loop_create_params_t create_params;
   state_event_loop_t *p_loop;
@@ -83,23 +74,20 @@ STATE_EVENT_LOOP_STORE_DECL(test_evl,
 
 STATE_EVENT_LOOP_STORE_DEF(test_evl);
 
-typedef struct
-{
+typedef struct {
   uint32_t count;
   uint32_t num_of_regs;
 } posted_counts_t;
 
-static void test_notifier_callback(notifier_block_t * block, uint32_t category, void *notif_data)
-{
-  posted_counts_t *count_array = (posted_counts_t *) notif_data;
+static void test_notifier_callback(notifier_block_t *block, uint32_t category, void *notif_data) {
+  posted_counts_t *count_array = (posted_counts_t *)notif_data;
 
   count_array[category].count++;
 }
 
-static void setup(void)
-{
-  char* sm_names[] = { "test_event_loop" };
-  uint32_t start_state[] = { 0 };
+static void setup(void) {
+  char *sm_names[] = {"test_event_loop"};
+  uint32_t start_state[] = {0};
   memset(&s_sel_data, 0, sizeof(s_sel_data));
   STATE_EVENT_LOOP_CREATE_PARAMS_INIT(s_sel_data.create_params,
                                       test_evl,
@@ -112,15 +100,11 @@ static void setup(void)
   event_flag_new(&s_sel_data.flags);
 }
 
-static void teardown(void)
-{
-  event_flag_free(&s_sel_data.flags);
-}
+static void teardown(void) { event_flag_free(&s_sel_data.flags); }
 
-static void test_state_init(state_machine_t * sm, state_t * state)
-{
-  test_state_t *test_state = (test_state_t *) state;
-  sel_test_data_t *p_loop = (sel_test_data_t *) state_machine_get_private_data(sm);
+static void test_state_init(state_machine_t *sm, state_t *state) {
+  test_state_t *test_state = (test_state_t *)state;
+  sel_test_data_t *p_loop = (sel_test_data_t *)state_machine_get_private_data(sm);
   if (p_loop == &s_sel_data) {
     event_flag_send(&s_sel_data.flags, TEST_FLAG_PRIVATE_DATA_VALID);
   } else {
@@ -130,17 +114,12 @@ static void test_state_init(state_machine_t * sm, state_t * state)
   p_loop->init_count++;
 }
 
-static void test_state_enter(state_machine_t * sm, state_t * state)
-{
-}
+static void test_state_enter(state_machine_t *sm, state_t *state) {}
 
-static void test_state_exit(state_machine_t * sm, state_t * state)
-{
-}
+static void test_state_exit(state_machine_t *sm, state_t *state) {}
 
-static bool test_state_valid_event(state_machine_t * sm, state_t * state, void *evt)
-{
-  test_event_t *event = (test_event_t *) evt;
+static bool test_state_valid_event(state_machine_t *sm, state_t *state, void *evt) {
+  test_event_t *event = (test_event_t *)evt;
 
   if (event->base.event_id < TEST_MAX_EVENT_ID)
     return true;
@@ -148,11 +127,10 @@ static bool test_state_valid_event(state_machine_t * sm, state_t * state, void *
     return false;
 }
 
-static uint32_t test_state_handle_event(state_machine_t * sm, state_t * state, void *evt)
-{
+static uint32_t test_state_handle_event(state_machine_t *sm, state_t *state, void *evt) {
   uint32_t next_state = state->stateId;
-  test_state_t *test_state = (test_state_t *) state;
-  test_event_t *event = (test_event_t *) evt;
+  test_state_t *test_state = (test_state_t *)state;
+  test_event_t *event = (test_event_t *)evt;
 
   switch (event->base.event_id) {
   case TRANSITION_EVENT:
@@ -166,13 +144,13 @@ static uint32_t test_state_handle_event(state_machine_t * sm, state_t * state, v
   return next_state;
 }
 
-static void can_post_to_state_machine(void)
-{
+static void can_post_to_state_machine(void) {
   uint32_t total_posts = 80;
 
   if (s_sel_data.create_params.event_data_size != sizeof(test_event_t)) {
     CLOG("Event Data size no match: event_data_size = %u, sizeof(test_event_t) = %u",
-         s_sel_data.create_params.event_data_size, sizeof(test_event_t));
+         s_sel_data.create_params.event_data_size,
+         sizeof(test_event_t));
     PRINT_FIELD(s_sel_data.create_params.event_data_size, u);
     PRINT_FIELD(s_sel_data.create_params.queue_params.queue_params.size, u);
     PRINT_FIELD(s_sel_data.create_params.queue_params.task_params.stack_size, u);
@@ -182,7 +160,7 @@ static void can_post_to_state_machine(void)
   s_sel_data.p_loop = state_event_loop_init(&s_sel_data.create_params);
   TEST_ASSERT(s_sel_data.p_loop);
   for (uint32_t i = 0; i < TEST_MAX_STATES; i++) {
-    state_t *state = (state_t *) & s_sel_data.states[i];
+    state_t *state = (state_t *)&s_sel_data.states[i];
 
     state->stateId = i;
     state->state_name = "Test State";
@@ -197,7 +175,7 @@ static void can_post_to_state_machine(void)
   TEST_ASSERT_EQUAL_INT(1, s_sel_data.init_count);
   uint32_t transition_count = 1;
   for (uint32_t i = 0; i < total_posts; i++) {
-    test_event_t event = {.base.event_id = (uint32_t) rand() % TEST_MAX_EVENT_ID };
+    test_event_t event = {.base.event_id = (uint32_t)rand() % TEST_MAX_EVENT_ID};
     uint32_t last_state_id = state_event_loop_get_current_state_id(s_sel_data.p_loop, 0);
 
     state_event_loop_post(s_sel_data.p_loop, event.base.event_id, &event.base);
@@ -207,7 +185,7 @@ static void can_post_to_state_machine(void)
     if (event.base.event_id == TRANSITION_EVENT) {
       uint32_t expected_new_state = (last_state_id + 1) % TEST_MAX_STATES;
       transition_count++;
-      if(transition_count <= TEST_MAX_STATES) {
+      if (transition_count <= TEST_MAX_STATES) {
         TEST_ASSERT_EQUAL_INT(transition_count, s_sel_data.init_count);
       } else {
         TEST_ASSERT_EQUAL_INT(TEST_MAX_STATES, s_sel_data.init_count);
@@ -230,17 +208,14 @@ static void can_post_to_state_machine(void)
   TEST_ASSERT_EQUAL_INT(TEST_MAX_STATES, s_sel_data.init_count);
 }
 
-TestRef state_event_loop_get_tests(void)
-{
-  EMB_UNIT_TESTFIXTURES(fixtures) {
-    new_TestFixture("Should post to state machine", can_post_to_state_machine)
-  };
+TestRef state_event_loop_get_tests(void) {
+  EMB_UNIT_TESTFIXTURES(fixtures){
+      new_TestFixture("Should post to state machine", can_post_to_state_machine)};
   EMB_UNIT_TESTCALLER(sel_tests, "State event loop tests", setup, teardown, fixtures);
-  return (TestRef) & sel_tests;
+  return (TestRef)&sel_tests;
 }
 
-int main()
-{
+int main() {
   TestRunner_start();
   {
     TestRunner_runTest(state_event_loop_get_tests());


### PR DESCRIPTION
Closes #6.

## Summary

Adds project formatting/lint configs and runs them across the codebase in
three commits:

1. **`.clang-format`** + C/C++ sources formatted (`inc/`, `src/`, `tests/`).
2. **`.cmake-format.yaml`** + CMake files formatted (all `CMakeLists.txt` +
   `cmake/*.cmake`).
3. **`.cmakelintrc`** + one long message split, so the standalone `cmakelint`
   linter agrees with the formatter.

Goals: a deterministic style baseline, no more editor spurious-diff churn on
save, and one-line version bumps for future style changes.

## Commit 1 — `.clang-format` + C/C++ format

Style established (verified against clang-format 22.1.6):
- 2-space indent, 100-column line limit
- `if (x)` — space after the control keyword, no space inside parens
- opening brace on the same line for functions and control blocks
- pointer asterisk on the right of the type (`state_t *p`, `void *ctx`)
- when a declaration/call wraps: one parameter per line, aligned to the first

`clang-format -i` across `inc/`, `src/`, `tests/` (`*.c`/`*.h`/`*.cpp`).
The CMake `configure_file` templates (`*.h.in`) are **excluded** —
clang-format mangles the `@VAR@` substitution tokens (this was the root cause
of the earlier space-inside-`@...@` issue on `Version.h.in`).

55 files changed (+2310/-2585). Formatting only — no logic changes.

## Commit 2 — `.cmake-format.yaml` + CMake format

Style established (verified against cmake-format 0.6.13):
- 2-space indent, 100-column line limit
- no space before the opening paren for any command — control (`if`/`foreach`/
  `endif`) or function (`set`/`message`/`option`): `if(...)`, `endif()`,
  `set(...)`
- no space inside parens: `set( X )` -> `set(X)`
- lowercase canonical command case

`cmake-format -i` across all `CMakeLists.txt` + `cmake/*.cmake` (excluding
`extern/`). cmake-format auto-discovers `.cmake-format.yaml` from the repo
root.

8 files changed (+160/-119). One known side effect: cmake-format joins
adjacent single-line comments in a few places (e.g. `src/CMakeLists.txt`:
`#Configure the platform specific stuff` + `#Currently only C11 APIs
supported` -> one wrapped line). Noted in the commit message; can be
revisited if it loses meaning.

## Commit 3 — `.cmakelintrc` + clear lint diagnostics

The standalone `cmakelint` linter (wired up by LazyVim's `lang.cmake` extra
via `nvim-lint`) reads `.cmakelintrc`, **not** `.cmake-format.yaml` — the
formatter and linter are separate tools with separate configs. `.cmakelintrc`
makes them agree:

- `linelength=120` — matches the formatter's 100-col target plus headroom for
  legitimate long lines. The linter's default of 80 was flagging every line
  the formatter produced between 80 and 100 cols.
- `filter=-whitespace/indent` — cmake-format is the authority on indentation;
  cmakelint's indent check expects multiples of 2 and conflicts with
  cmake-format's continuation-line alignment (args aligned to the first arg
  of a wrapped command). Removes the spurious "Weird indentation; use 2
  spaces" diagnostics.
- `filter=-readability/wonkycase` — CMake's own module commands are
  mixed-case by upstream design (`FetchContent_Declare`,
  `FetchContent_MakeAvailable`); flagging them is a false positive.

Also splits the one 178-char `FATAL_ERROR` message in the top-level
`CMakeLists.txt` into two adjacent string literals (CMake concatenates
adjacent segments at runtime; cmake-format preserves this form) so it stays
under 120 cols while remaining a single runtime message.

After this commit, `cmakelint` reports 0 errors across all CMake files.

## Verification

- **Build:** clean `cmake -B build -S . && cmake --build build` succeeds for
  all three commits.
- **ctest:** 32/42 pass for all three commits. The 10 failures are the
  pre-existing threading/timing tests (`TaskTest.TaskApiTest`,
  `TaskTest.BasicPremption`, `ts_queue_test.ShouldBlockOnEmptyQueue/
  ShouldBlockOnFullQueue/ProducerConsumerShouldRun`) — identical to the
  pre-format baseline, so **zero regressions**.
- **`cmakelint`:** 0 errors across all `CMakeLists.txt` + `cmake/*.cmake`.
- **`git diff -w`** of the formatting commits shows no substantive (non-
  whitespace) changes.

## Scope

- **In:** `inc/`, `src/`, `tests/`, `cmake/`, all root `CMakeLists.txt`.
- **Out:** `extern/` (third-party), `build/`, `.cache/`, `*.h.in` templates.

## Editor-side (not in this PR)

LazyVim's `lang.cmake` extra installs `cmake-format` via mason but does not
add `cmake = { "cmake_format" }` to conform's `formatters_by_ft`. To enable
CMake format-on-save, add a `~/.config/nvim/lua/plugins/conform-cmake.lua`
override (lazy.nvim deep-merges opts, so the stylua/fish/shfmt defaults are
preserved). C/C++ format-on-save already works out of the box via LazyVim's
default `clang-format` wiring — the `.clang-format` committed here makes it
deterministic.

## Follow-ups (out of scope)

- The `if(... AND ...)` wrapping in `src/CMakeLists.txt` aligns the second
  condition to column ~56 (a cmake-format limitation; it cannot do
  one-condition-per-line automatically — only `# cmake-format: off` markers
  work). Left as-is per the issue discussion.
- A CI step running `clang-format --dry-run -Werror` and `cmake-format --check`
  could prevent unformatted code from landing. Separate issue if wanted.