### PR TITLE
fix(#15): build pool_tests task params via portable init macro

### DIFF
--- a/inc/cutils/c11/task.h
+++ b/inc/cutils/c11/task.h
@@ -77,15 +77,18 @@ typedef struct _task_create_params_t {
 #define TASK_STATIC_STORE_DEF(name)                                                                \
   TASK_STATIC_STORE_T(name) TASK_STATIC_STORE(name) __attribute__((section(".bss.noinit"), used))
 
-#define TASK_STATIC_INIT_CREATE_PARAMS(params, name, lbl, pri, fn, context)                        \
+#define TASK_INIT_CREATE_PARAMS_FROM_STORE(params, store_ptr, lbl, pri, fn, context)               \
   memset(&(params), 0, sizeof((params)));                                                          \
-  (params).task = &TASK_STATIC_STORE(name).tsk;                                                    \
+  (params).task = &(store_ptr)->tsk;                                                               \
   (params).label = (char *)(lbl);                                                                  \
   (params).priority = pri;                                                                         \
   (params).func = fn;                                                                              \
   (params).ctx = context;                                                                          \
-  (params).stack = TASK_STATIC_STORE(name).stack;                                                  \
-  (params).stack_size = sizeof(TASK_STATIC_STORE(name).stack)
+  (params).stack = (store_ptr)->stack;                                                             \
+  (params).stack_size = sizeof((store_ptr)->stack)
+
+#define TASK_STATIC_INIT_CREATE_PARAMS(params, name, lbl, pri, fn, context)                        \
+  TASK_INIT_CREATE_PARAMS_FROM_STORE(params, &TASK_STATIC_STORE(name), lbl, pri, fn, context)
 
 task_t *task_new_static(task_create_params_t *create_params);
 

--- a/inc/cutils/freertos/task.h
+++ b/inc/cutils/freertos/task.h
@@ -84,16 +84,19 @@ typedef struct _task_create_params_t {
 #define TASK_STATIC_STORE_DEF(name)                                                                \
   TASK_STATIC_STORE_T(name) TASK_STATIC_STORE(name) __attribute__((used))
 
-#define TASK_STATIC_INIT_CREATE_PARAMS(params, name, lbl, pri, fn, context)                        \
+#define TASK_INIT_CREATE_PARAMS_FROM_STORE(params, store_ptr, lbl, pri, fn, context)               \
   memset(&(params), 0, sizeof((params)));                                                          \
-  (params).task = &TASK_STATIC_STORE(name).tsk;                                                    \
-  (params).tcb = &(((params).task)->tcb);                                                          \
+  (params).task = &(store_ptr)->tsk;                                                               \
+  (params).tcb = &((store_ptr)->tsk.tcb);                                                          \
   (params).label = (char *)(lbl);                                                                  \
   (params).priority = pri;                                                                         \
   (params).func = fn;                                                                              \
   (params).ctx = context;                                                                          \
-  (params).stack = TASK_STATIC_STORE(name).stack;                                                  \
-  (params).stack_size = sizeof(TASK_STATIC_STORE(name).stack)
+  (params).stack = (store_ptr)->stack;                                                             \
+  (params).stack_size = sizeof((store_ptr)->stack)
+
+#define TASK_STATIC_INIT_CREATE_PARAMS(params, name, lbl, pri, fn, context)                        \
+  TASK_INIT_CREATE_PARAMS_FROM_STORE(params, &TASK_STATIC_STORE(name), lbl, pri, fn, context)
 
 task_t *task_new_static(task_create_params_t *create_params);
 

--- a/inc/cutils/pthread/task.h
+++ b/inc/cutils/pthread/task.h
@@ -78,15 +78,18 @@ typedef struct _task_create_params_t {
 #define TASK_STATIC_STORE_DEF(name)                                                                \
   TASK_STATIC_STORE_T(name) TASK_STATIC_STORE(name) __attribute__((section(".bss.noinit"), used))
 
-#define TASK_STATIC_INIT_CREATE_PARAMS(params, name, lbl, pri, fn, context)                        \
+#define TASK_INIT_CREATE_PARAMS_FROM_STORE(params, store_ptr, lbl, pri, fn, context)               \
   memset(&(params), 0, sizeof((params)));                                                          \
-  (params).task = &TASK_STATIC_STORE(name).tsk;                                                    \
+  (params).task = &(store_ptr)->tsk;                                                               \
   (params).label = (char *)(lbl);                                                                  \
   (params).priority = pri;                                                                         \
   (params).func = fn;                                                                              \
   (params).ctx = context;                                                                          \
-  (params).stack = TASK_STATIC_STORE(name).stack;                                                  \
-  (params).stack_size = sizeof(TASK_STATIC_STORE(name).stack)
+  (params).stack = (store_ptr)->stack;                                                             \
+  (params).stack_size = sizeof((store_ptr)->stack)
+
+#define TASK_STATIC_INIT_CREATE_PARAMS(params, name, lbl, pri, fn, context)                        \
+  TASK_INIT_CREATE_PARAMS_FROM_STORE(params, &TASK_STATIC_STORE(name), lbl, pri, fn, context)
 
 task_t *task_new_static(task_create_params_t *create_params);
 

--- a/tests/pool_tests.c
+++ b/tests/pool_tests.c
@@ -227,14 +227,13 @@ static void launcher_action(void *ctx) {
   for (uint32_t i = 0; i < NUM_OF_THREADS; i++) {
     p_test_data->retainerStores[i] = malloc(sizeof(TASK_STATIC_STORE_T(retainer_task)));
     if (p_test_data->retainerStores[i]) {
-      task_create_params_t retainer_params = {.task = &p_test_data->retainerStores[i]->tsk,
-                                              .stack = p_test_data->retainerStores[i]->stack,
-                                              .stack_size =
-                                                  sizeof(p_test_data->retainerStores[i]->stack),
-                                              .label = "RetainerTask",
-                                              .priority = CUTILS_TASK_PRIORITY_MID_LO,
-                                              .func = pool_retainer_action,
-                                              .ctx = p_test_data};
+      task_create_params_t retainer_params;
+      TASK_INIT_CREATE_PARAMS_FROM_STORE(retainer_params,
+                                         p_test_data->retainerStores[i],
+                                         "RetainerTask",
+                                         CUTILS_TASK_PRIORITY_MID_LO,
+                                         pool_retainer_action,
+                                         p_test_data);
       memset(retainer_params.task, 0, sizeof(task_t));
       if (!task_new_static(&retainer_params)) {
         p_test_data->result = POOL_RETAIN_TEST_FAIL_CREATE;
@@ -283,14 +282,13 @@ static void pool_multi_thread_alloc_test(void) {
     s_test_data2.p_launcher_store = malloc(sizeof(TASK_STATIC_STORE_T(launcher_task)));
 
     if (s_test_data2.p_launcher_store) {
-      task_create_params_t launcher_params = {.task = &s_test_data2.p_launcher_store->tsk,
-                                              .stack = s_test_data2.p_launcher_store->stack,
-                                              .stack_size =
-                                                  sizeof(s_test_data2.p_launcher_store->stack),
-                                              .priority = CUTILS_TASK_PRIORITY_HIGHEST,
-                                              .label = "LauncherTask",
-                                              .func = launcher_action,
-                                              .ctx = &s_test_data2};
+      task_create_params_t launcher_params;
+      TASK_INIT_CREATE_PARAMS_FROM_STORE(launcher_params,
+                                         s_test_data2.p_launcher_store,
+                                         "LauncherTask",
+                                         CUTILS_TASK_PRIORITY_HIGHEST,
+                                         launcher_action,
+                                         &s_test_data2);
       launcher_task = task_new_static(&launcher_params);
       if (!launcher_task) {
         free(s_test_data2.p_launcher_store);


### PR DESCRIPTION
## Summary

Closes #15.

`pool_tests.c` constructed `task_create_params_t` with designated initializers that directly addressed port-specific fields, omitting FreeRTOS' `.tcb` (defaulting to `NULL`) and coupling shared tests to one port's struct layout. This is the portable-API contract violation described in #15.

## Changes

- **`inc/cutils/{pthread,c11,freertos}/task.h`**: Add `TASK_INIT_CREATE_PARAMS_FROM_STORE(params, store_ptr, lbl, pri, fn, context)`, which derives `.task`, `.stack`, `.stack_size` (and `.tcb` on FreeRTOS) from a `TASK_STATIC_STORE_T*` pointer. This works for both global static stores and heap-allocated stores — `pool_tests` mallocs 1000 retainer stores, so it can't use a global store. `TASK_STATIC_INIT_CREATE_PARAMS` is refactored to delegate to the new macro so the two cannot drift.
- **`tests/pool_tests.c`**: Replace the two designated-initializer blocks (`retainer_params` in `launcher_action`, `launcher_params` in `pool_multi_thread_alloc_test`) with the new macro. No `#ifdef` or `.tcb` reference remains in test code.

## Verification

- **pthread (host)**: `os_test` and `all_embunit_tests` pass via ctest. (The `pool_tests` multi-thread test fails on this host due to `pthread_create` returning `EPERM` — `PTHREAD_EXPLICIT_SCHED` needs `CAP_SYS_NICE`, absent in this container; this is pre-existing and identical on `master`, unrelated to #15.)
- **freertos (QEMU mps2-an500)**: `embtest_runner` passes (exit 0); the `pool` suite is green 5/5, including `pool_multi_thread_alloc_test` — the test that originally exposed the `.tcb` bug.
- **c11**: header change mirrors pthread (identical, no `.tcb`); the c11 platform is pre-existing broken on this host for unrelated `_GNU_SOURCE`/`c11threads` reasons, so it's not buildable here regardless of this change.
- `clang-format`: new code is clean (the 3 remaining violations in `pthread/task.h` are pre-existing on `master`).
- The FreeRTOS `task_new_static` NULL-`.tcb` workaround in `src/freertos/task.c` is intentionally left in place as defense in depth (reverting it is out of scope for #15).

## Audit

`grep -rn 'task_create_params_t.*=.*{' tests/` confirms `pool_tests.c` was the only test file with this pattern; `os_test.c` and `tests/freertos/GCC_ARM_CM7/main.c` already used the portable macro.
