### PR TITLE
fix(#12): correct inverted CUTILS_TASK_PRIORITY_MID_HIGH/MID_LO in pthread and c11 task.h

### DIFF
--- a/inc/cutils/c11/task.h
+++ b/inc/cutils/c11/task.h
@@ -38,9 +38,9 @@ extern "C" {
 #define CUTILS_TASK_PRIORITY_MEDIUM                                                                \
   ((CUTILS_TASK_PRIORITY_LOWEST + CUTILS_TASK_PRIORITY_HIGHEST) / 2)
 #define CUTILS_TASK_PRIORITY_MID_HIGH                                                              \
-  (CUTILS_TASK_PRIORITY_MEDIUM - ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST) / 4))
-#define CUTILS_TASK_PRIORITY_MID_LO                                                                \
   (CUTILS_TASK_PRIORITY_MEDIUM + ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST) / 4))
+#define CUTILS_TASK_PRIORITY_MID_LO                                                                \
+  (CUTILS_TASK_PRIORITY_MEDIUM - ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST) / 4))
 /** @} */
 
 #define CUTILS_TASK_STACK_MIN_SIZE (PTHREAD_STACK_MIN)

--- a/inc/cutils/pthread/task.h
+++ b/inc/cutils/pthread/task.h
@@ -40,9 +40,9 @@ extern "C" {
 #define CUTILS_TASK_PRIORITY_MEDIUM                                                                \
   ((CUTILS_TASK_PRIORITY_LOWEST + CUTILS_TASK_PRIORITY_HIGHEST) / 2)
 #define CUTILS_TASK_PRIORITY_MID_HIGH                                                              \
-  (CUTILS_TASK_PRIORITY_MEDIUM - ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST) / 4))
-#define CUTILS_TASK_PRIORITY_MID_LO                                                                \
   (CUTILS_TASK_PRIORITY_MEDIUM + ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST) / 4))
+#define CUTILS_TASK_PRIORITY_MID_LO                                                                \
+  (CUTILS_TASK_PRIORITY_MEDIUM - ((CUTILS_TASK_PRIORITY_HIGHEST - CUTILS_TASK_PRIORITY_LOWEST) / 4))
 /** @} */
 
 #define CUTILS_TASK_STACK_MIN_SIZE (PTHREAD_STACK_MIN)


### PR DESCRIPTION
## Summary

Fixes the inverted `CUTILS_TASK_PRIORITY_MID_HIGH` / `MID_LO` macros. POSIX
uses higher-numeric-value = higher-priority semantics, so `MID_HIGH` must be
`>= MEDIUM` and `MID_LO` `<= MEDIUM`. Both the **pthread** and **c11** ports had
the signs backwards: `MID_HIGH` subtracted from `MEDIUM` (yielding a *lower*
priority) and `MID_LO` added (yielding a *higher* priority).

```diff
- #define CUTILS_TASK_PRIORITY_MID_HIGH  (CUTILS_TASK_PRIORITY_MEDIUM - ((HIGHEST - LOWEST) / 4))
- #define CUTILS_TASK_PRIORITY_MID_LO    (CUTILS_TASK_PRIORITY_MEDIUM + ((HIGHEST - LOWEST) / 4))
+ #define CUTILS_TASK_PRIORITY_MID_HIGH  (CUTILS_TASK_PRIORITY_MEDIUM + ((HIGHEST - LOWEST) / 4))
+ #define CUTILS_TASK_PRIORITY_MID_LO    (CUTILS_TASK_PRIORITY_MEDIUM - ((HIGHEST - LOWEST) / 4))
```

Applied to both `inc/cutils/pthread/task.h` and `inc/cutils/c11/task.h`.

## Why it went unnoticed

On the typical Linux host, `SCHED_OTHER` reports
`sched_get_priority_min == sched_get_priority_max == 0`, so every macro
collapses to `0` and the inversion has zero observable effect. It only
matters on policies where `min < max` (e.g. `SCHED_FIFO`, 1..99) or on the
FreeRTOS port where the numbers actually differ (`inc/cutils/freertos/task.h`
already had the correct direction).

## Scope note

Issue #12's body only called out the pthread port. While fixing it I found the
**c11 port carries the identical bug** (same macro expressions, same
`SCHED_OTHER` policy via `c11threads.h`), so this PR fixes both for
consistency. The c11 half is technically beyond the literal text of #12 but is
the same defect.

## Verification

Standalone check replicating the exact macro arithmetic:

- **SCHED_OTHER (shipped header):** all macros = 0 → no behavioral regression
  on Linux host (issue acceptance criterion #3).
- **SCHED_FIFO (min=1, max=99):** fixed direction → `medium=50, mid_high=74,
  mid_lo=26` → `MID_HIGH >= MEDIUM >= MID_LO` ✓. Inverted direction →
  `mid_high=26, mid_lo=74` (violates the invariant), confirming the test
  actually catches the bug.

Host pthread build (`cmake --build build-pthread`): green. `ctest`: 7/10, at
parity with `master`. The 3 segfaults (`dispatch_queue_tests`,
`asyncio_tests`, `state_event_loop_tests`) are pre-existing per #19
(`PTHREAD_EXPLICIT_SCHED` → `pthread_create` EPERM unprivileged) and unrelated
to this change.

Closes #12.