### PR TITLE
fix(#3): remove unconditional USE_STD_PRINTF define from platform_abstraction

### DIFF
--- a/src/c11/CMakeLists.txt
+++ b/src/c11/CMakeLists.txt
@@ -9,6 +9,6 @@ add_library(platform_abstraction STATIC "${PLATFORM_HEADER_LIST}" "${HEADER_LIST
 set_target_properties(platform_abstraction PROPERTIES LINKER_LANGUAGE C)
 target_compile_options(platform_abstraction PUBLIC -std=gnu11)
 target_compile_features(platform_abstraction PUBLIC c_std_11)
-target_compile_definitions(platform_abstraction PUBLIC -DUSE_STD_PRINTF -D_GNU_SOURCE)
+target_compile_definitions(platform_abstraction PUBLIC -D_GNU_SOURCE)
 target_link_libraries(platform_abstraction ${CMAKE_THREAD_LIBS_INIT} logger_basic)
 target_include_directories(platform_abstraction PUBLIC ${API_INCLUDES})

--- a/src/pthread/CMakeLists.txt
+++ b/src/pthread/CMakeLists.txt
@@ -8,6 +8,6 @@ add_library(platform_abstraction STATIC "${PLATFORM_HEADER_LIST}" "${HEADER_LIST
                                         "${PLATFORM_SOURCES}")
 set_target_properties(platform_abstraction PROPERTIES LINKER_LANGUAGE C)
 target_compile_features(platform_abstraction PUBLIC c_std_11)
-target_compile_definitions(platform_abstraction PUBLIC -DUSE_STD_PRINTF)
+
 target_link_libraries(platform_abstraction ${CMAKE_THREAD_LIBS_INIT} logger_basic)
 target_include_directories(platform_abstraction PUBLIC ${API_INCLUDES})


### PR DESCRIPTION
## Summary

Closes #3. The `USE_STD_PRINTF` CMake option was bypassed by two lines that unconditionally defined `-DUSE_STD_PRINTF PUBLIC` on the `platform_abstraction` targets in both pthread and c11, making `-DUSE_STD_PRINTF=OFF` inconsistent — some sources received it anyway.

## Fix

- Removed `target_compile_definitions(platform_abstraction PUBLIC -DUSE_STD_PRINTF)` from `src/pthread/CMakeLists.txt`.
- Changed the corresponding line in `src/c11/CMakeLists.txt` to keep only `-D_GNU_SOURCE`.

The option now fully controls the define through `add_definitions(-DUSE_STD_PRINTF)` in `src/CMakeLists.txt`, which propagates consistently because it's issued before any `add_subdirectory` calls into either C11 or pthread.

## Verification

```bash
# OFF: no target should carry the define
rm -rf build && cmake -B build -S . -DUSE_STD_PRINTF=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
grep 'logger.c' compile_commands.json | grep USE_STD_PRINTF  # expect: (no match)
grep 'ring_buffer.c\|task.c'    compile_commands.json | grep USE_STD_PRINTF  # same

# ON (default): sources including platform ones get it
rm -rf build && cmake -B build -S . -DUSE_STD_PRINTF=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
grep 'logger.c'     compile_commands.json | grep -c USE_STD_PRINTF +0
grep 'ring_buffer.c' compile_commands.json | grep -c USE_STD_PRINTF +1  # present
```

## Existing test failures (unrelated)

3 tests segfault on both branches — pre-existing, not caused by this change:
- dispatch_queue_tests
- asyncio_tests
- state_event_loop_tests
