### PR TITLE
feat(#14): introduce per-port cutils_ticks_t for native tick type

### DIFF
--- a/inc/cutils/c11/task.h
+++ b/inc/cutils/c11/task.h
@@ -30,6 +30,14 @@
 extern "C" {
 #endif
 
+/**
+ * @brief cutils-level ticks type, defined per port to its native tick width.
+ * On RTOS ports this may be 32-bit (per FreeRTOS configTICK_TYPE_WIDTH_IN_BITS);
+ * code computing deltas or storing ticks should use cutils_ticks_t directly
+ * and not assume uint64_t. Host portable ports typically resolve to uint64_t via clock_gettime.
+ */
+typedef uint64_t cutils_ticks_t;
+
 /** @name Task Priority Levels
  *  These macros define the priority range for tasks on this port.
  *  @{ */
@@ -118,8 +126,6 @@ task_t *task_new_static(task_create_params_t *create_params);
 bool task_start(task_t *task);
 
 void task_destroy_static(task_t *task);
-
-uint64_t task_get_ticks(void);
 
 void task_sleep(uint32_t ms);
 

--- a/inc/cutils/freertos/task.h
+++ b/inc/cutils/freertos/task.h
@@ -25,12 +25,21 @@
 
 #include <FreeRTOS.h>
 #include <cutils/os_types.h>
+
 #include <stdalign.h>
 #include <task.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief cutils-level ticks type, defined per port to its native tick width.
+ * On RTOS ports this may be 32-bit (per FreeRTOS configTICK_TYPE_WIDTH_IN_BITS);
+ * code computing deltas or storing ticks should use cutils_ticks_t directly
+ * and not assume uint64_t. Host portable ports typically resolve to uint64_t.
+ */
+typedef TickType_t cutils_ticks_t;
 
 /** @name Task Priority Levels
  *  These macros define the priority range for tasks on this port.

--- a/inc/cutils/pthread/task.h
+++ b/inc/cutils/pthread/task.h
@@ -54,6 +54,14 @@ extern "C" {
 typedef void (*task_func_t)(void *);
 
 /**
+ * @brief cutils-level ticks type, defined per port to its native tick width.
+ * On RTOS ports this may be 32-bit — code computing deltas or storing ticks
+ * should use cutils_ticks_t directly and not assume uint64_t. Host pthread
+ * (and other portable hosts) typically resolves to uint64_t via clock_gettime.
+ */
+typedef uint64_t cutils_ticks_t;
+
+/**
  * @brief The internal representation of a task on the pthread port.
  */
 typedef struct _task_t {

--- a/inc/cutils/task.h.in
+++ b/inc/cutils/task.h.in
@@ -56,7 +56,7 @@ void task_destroy_static(task_t *task);
  * @brief Retrieves the current system tick count.
  * @return The number of ticks since system start.
  */
-uint64_t task_get_ticks(void);
+cutils_ticks_t task_get_ticks(void);
 
 /**
  * @brief Puts the currently running task to sleep.

--- a/src/c11/task.c
+++ b/src/c11/task.c
@@ -71,7 +71,7 @@ void task_destroy_static(task_t *task) {
 }
 bool task_start(task_t *task) { return true; }
 
-uint64_t task_get_ticks(void) {
+cutils_ticks_t task_get_ticks(void) {
   struct timespec res = {0};
   clock_gettime(CLOCK_REALTIME, &res);
   return res.tv_sec * 1000000000 + res.tv_nsec;

--- a/src/freertos/task.c
+++ b/src/freertos/task.c
@@ -41,12 +41,12 @@ void task_destroy_static(task_t *task) {
   }
 }
 
-uint64_t task_get_ticks(void) {
-  /* xTaskGetTickCount() returns TickType_t (uint32_t with our 32-bit tick
-   * config). Widening to uint64_t is exact but the underlying counter rolls
-   * over every ~49.7 days at 1 kHz; a 64-bit overflow-tracking wrapper can be
-   * added later if a test needs longer uptimes. */
-  return (uint64_t)xTaskGetTickCount();
+cutils_ticks_t task_get_ticks(void) {
+  /* xTaskGetTickCount() returns TickType_t; with configTICK_TYPE_WIDTH_IN_BITS=32
+   * returning it as cutils_ticks_t (TickType_t here) is lossless, but the counter
+   * still wraps every ~49.7 days at 1 kHz -- callers should be aware of tick
+   * width if computing deltas over long uptimes. */
+  return xTaskGetTickCount();
 }
 
 void task_sleep(uint32_t ms) {

--- a/src/pthread/task.c
+++ b/src/pthread/task.c
@@ -96,7 +96,7 @@ void task_destroy_static(task_t *task) {
 }
 bool task_start(task_t *task) { return true; }
 
-uint64_t task_get_ticks(void) {
+cutils_ticks_t task_get_ticks(void) {
   struct timespec res = {0};
   clock_gettime(CLOCK_REALTIME, &res);
   return res.tv_sec * 1000000000 + res.tv_nsec;


### PR DESCRIPTION
## Summary

Introduces a per-port `cutils_ticks_t` typedef defined to each port's native tick width, and changes `task_get_ticks` to return it. Closes #14.

- pthread / c11: `typedef uint64_t cutils_ticks_t;` (native via `clock_gettime`)
- freertos: `typedef TickType_t cutils_ticks_t;` (`uint32_t` with `configTICK_TYPE_WIDTH_IN_BITS=32`)
- `task_get_ticks` prototype hoisted to `task.h.in` returning `cutils_ticks_t`; the port header is included before the prototype so the typedef is visible.
- freertos `task_get_ticks` now returns `xTaskGetTickCount()` directly — no widening cast.
- Stale `uint64_t task_get_ticks(void);` prototype removed from the c11 port header (the pthread/freertos headers already had no such duplicate).
- Typedef documented on all three ports regarding possible 32-bit width / ~49.7-day wrap on RTOS.

## Acceptance criteria (#14)

- [x] `cutils_ticks_t` defined in each port header (`pthread`, `c11`, `freertos`) to its native tick type
- [x] `task_get_ticks` prototype returns `cutils_ticks_t` (hoisted to `task.h.in`)
- [x] freertos `task_get_ticks` returns `xTaskGetTickCount()` with no widening cast
- [x] pthread/c11 `task_get_ticks` unchanged behavior (`uint64_t` native)
- [x] Callers compile and pass; host `ctest` green (no new regressions vs `master`)
- [x] Typedef documented re: possible 32-bit width / wrap

## Verification

- **c11 build**: clean
- **pthread build**: clean; `ctest` → 7/10 pass. The 3 failures (`dispatch_queue_tests`, `asyncio_tests`, `state_event_loop_tests`) are **pre-existing on `master`** (identical 70% pass rate, same 3 tests) — not introduced by this change.
- **freertos cross-build** (ARM): links `embtest_runner` cleanly.
- Include ordering in `task.h.in` verified: port header included (line 33) before the `cutils_ticks_t` prototype (line 59).
- Reviewed by a fresh-context `reviewer` subagent against the issue; verdict: all six acceptance criteria MET, no blockers, no scope creep.

## Out of scope (flagged for follow-up)

- Pre-existing caller width assumptions (`src/state_event_loop.c:165` and `inc/cutils/logger.h:140` store ticks in `uint32_t`) — acknowledged as a non-issue in #14 for test timescales; candidate for a future tech-debt ticket.
- c11 port header still re-declares other `task_*` prototypes (`task_new_static`, `task_start`, `task_destroy_static`, `task_sleep`, `task_get_current_name`) duplicating `task.h.in`. This is #13 territory (header refactor) and intentionally left untouched here.

Refs: #11