### PR TITLE
refactor(#13): remove duplicated task prototypes from c11 port header

### DIFF
--- a/inc/cutils/c11/task.h
+++ b/inc/cutils/c11/task.h
@@ -121,16 +121,6 @@ typedef struct _task_create_params_t {
   TASK_INIT_CREATE_PARAMS_FROM_STORE(params, &TASK_STATIC_STORE(name), lbl, pri, fn, context)
 /** @} */
 
-task_t *task_new_static(task_create_params_t *create_params);
-
-bool task_start(task_t *task);
-
-void task_destroy_static(task_t *task);
-
-void task_sleep(uint32_t ms);
-
-void task_get_current_name(char *name, size_t string_length);
-
 #ifdef __cplusplus
 };
 #endif


### PR DESCRIPTION
## Summary

Completes the c11 side of #13 by removing the five `task_*` prototypes that were duplicated between the c11 port header and the cutils-level `task.h.in`. The pthread and freertos port headers already follow the single-source pattern (port header holds only port-specific types/macros; `task.h.in` owns the public API surface); this aligns c11 with them.

Removed from `inc/cutils/c11/task.h`:
- `task_t *task_new_static(task_create_params_t *);`
- `bool task_start(task_t *);`
- `void task_destroy_static(task_t *);`
- `void task_sleep(uint32_t ms);`
- `void task_get_current_name(char *, size_t);`

These remain canonically declared in `inc/cutils/task.h.in`, which includes the port header before using its types.

## Why now

During #14 (PR #26) the c11 port header was found to still carry a **stale** `uint64_t task_get_ticks(void);` prototype alongside the new `cutils_ticks_t` typedef — exactly the kind of drift the duplication enables. That stale prototype was removed as part of #14, but the broader duplication of the other `task_*` prototypes was left untouched there as #13 territory. This PR cleans up the remainder.

## Verification

- **c11 build**: clean
- **pthread build**: clean
- **freertos cross-build** (ARM): links `embtest_runner` cleanly
- No behavioral change (prototype removal only; `task.h.in` already provides the canonical declarations)

Refs: #13