### PR TITLE
fix(#19): fall back to PTHREAD_INHERIT_SCHED on EPERM in task_new_static

### DIFF
--- a/src/pthread/task.c
+++ b/src/pthread/task.c
@@ -24,6 +24,7 @@
 
 #include <cutils/logger.h>
 #include <cutils/task.h>
+#include <errno.h>
 #include <pthread.h>
 #include <string.h>
 
@@ -56,6 +57,10 @@ task_t *task_new_static(task_create_params_t *create_params) {
     int rval = pthread_attr_getstacksize(&attr, &min_stack_size);
     CHECK_RUN(!rval, pthread_attr_destroy(&attr);
               return retval, "Failed to query minimum stack size");
+    /* Explicit scheduling (policy + priority) requires CAP_SYS_NICE on Linux.
+     * Unprivileged callers will see pthread_create() fail with EPERM below; we
+     * then retry once with PTHREAD_INHERIT_SCHED, which for SCHED_OTHER yields
+     * the same prio-0 thread the explicit path would have produced. */
     rval = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
     CHECK_RUN(!rval, pthread_attr_destroy(&attr);
               return retval, "Failed to set scheduling parameter");
@@ -70,14 +75,26 @@ task_t *task_new_static(task_create_params_t *create_params) {
       CHECK_RUN(!rval, pthread_attr_destroy(&attr);
                 return retval, "Failed to set stack", create_params->stack);
     }
-    CHECK_RUN(!rval, pthread_attr_destroy(&attr);
-              return retval,
-                     "Failed to set scheduling priority between (%d, %d)",
-                     sched_get_priority_min(SCHEDULING_POLICY),
-                     sched_get_priority_max(SCHEDULING_POLICY));
+
     create_params->task->ctx = create_params->ctx;
     create_params->task->func = create_params->func;
+
     int res = pthread_create(&create_params->task->task, &attr, task_runner, create_params->task);
+    if (res == EPERM) {
+      /* PTHREAD_EXPLICIT_SCHED needs CAP_SYS_NICE. Fall back to the platform
+       * default scheduling (inherited from the creating thread). */
+      CLOG("task_new_static: pthread_create returned EPERM under PTHREAD_EXPLICIT_SCHED for "
+           "'%s'; retrying with PTHREAD_INHERIT_SCHED",
+           create_params->label ? create_params->label : "(null)");
+      pthread_attr_destroy(&attr);
+      pthread_attr_init(&attr);
+      if (create_params->stack && create_params->stack_size >= min_stack_size) {
+        pthread_attr_setstack(&attr, create_params->stack, create_params->stack_size);
+      }
+      res = pthread_create(&create_params->task->task, &attr, task_runner, create_params->task);
+    }
+    pthread_attr_destroy(&attr);
+
     create_params->task->sanity = TASK_SANITY;
     strncpy(
         create_params->task->label, create_params->label, sizeof(create_params->task->label) - 1);


### PR DESCRIPTION
## Summary

Closes #19.

Three pthread-host ctest suites (`dispatch_queue_tests`, `asyncio_tests`, `state_event_loop_tests`) deterministically `SIGSEGV`'d on `master` for any unprivileged developer. Root cause: `task_new_static` (`src/pthread/task.c`) unconditionally set `PTHREAD_EXPLICIT_SCHED` on the thread attr, which on Linux requires `CAP_SYS_NICE`. Without it, `pthread_create` returns `EPERM`, `task_new_static` returns `NULL`, and `dispatch_queue_create`'s `CUTILS_ASSERTF` performed its deliberate null-deref — surfacing as the segfault.

## Fix

Retry `pthread_create` once with `PTHREAD_INHERIT_SCHED` when it fails with `EPERM` (option 2 from the issue).

This is the right call because on Linux `sched_get_priority_min/max(SCHED_OTHER)` both return `0` — so every `CUTILS_TASK_PRIORITY_*` macro resolves to `0` and the explicit-scheduling block only ever requested a prio-0 `SCHED_OTHER` thread, which is *exactly* what the inherited default produces, while adding the `CAP_SYS_NICE` requirement. I verified this with a minimal standalone repro (`pthread_create=1 (EPERM)` as a normal user, `0` as root).

So:
- **Privileged context (root / capable CI / future SCHED_FIFO policy):** keeps the explicit policy+priority path — no behavior change.
- **Unprivileged developer:** degrades cleanly to the platform default, which produces the identical `SCHED_OTHER`/prio-0 thread the explicit path would have produced.

Drive-by cleanups in the same function:
- Dropped a stale trailing `CHECK_RUN` that re-checked the *stack-set* `rval` with a *priority-range* message (copy-paste artifact; effectively dead since prior `CHECK_RUN`s already returned on failure).
- `pthread_attr_destroy(&attr)` is now called on all paths (previously leaked on the success path).

## Verification

```
cmake -S . -B build-pthread -DCMAKE_BUILD_TYPE=Debug -DCMAKE_BUILD_TYPE=pthread
cmake --build build-pthread
cd build-pthread && ctest
```

Before — the three suites `***Exception: SegFault`.
After:

```
6/10 Test #6: dispatch_queue_tests .............   Passed    0.12 sec
8/10 Test #8: asyncio_tests ....................   Passed    1.00 sec
9/10 Test #9: state_event_loop_tests ...........   Passed    0.08 sec
...
100% tests passed, 0 tests failed out of 10
```

Confirmed the EPERM fallback is actually exercised (not silently bypassed):

```
task_new_static(86): pthread_create returned EPERM under PTHREAD_EXPLICIT_SCHED for 'test_dispatch_queue1'; retrying with PTHREAD_INHERIT_SCHED
```

Clean build (no warnings), clang-format clean.

## Note (out of scope)

`inc/cutils/c11/c11threads.h`'s `thrd_create_ex` has the identical `PTHREAD_EXPLICIT_SCHED`-without-fallback anti-pattern. The c11 port's task tests are currently gated off (the `CUTILS_TASK_USES_THRD_CREATE` / `RTOS_TASK_IMPLEMENTED` macros referenced by `os_test.c` / `queue_test.c` aren't defined anywhere in the tree), so nothing fails today, but it'll bite the moment that port's task tests are enabled. Worth a separate follow-up issue rather than expanding this PR's scope.