### PR TITLE
Add CMakePresets and always emit compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ compile_commands.json
 # MemPalace per-project files (issue #185)
 mempalace.yaml
 entities.json
+
+# CMake user-local preset overrides (CMakePresets.json is committed; this is not)
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,13 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.21)
 project(
   cutils
   VERSION 0.0.1
   LANGUAGES C
 )
+
+# Always emit compile_commands.json for clangd/IDE indexing. Effective on Makefile and Ninja
+# (single-config) generators; no-op on multi-config generators (Ninja Multi-Config, VS, Xcode).
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 function(print_list theList)
   foreach(item ${theList})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,92 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": { "major": 3, "minor": 21, "patch": 0 },
+  "configurePresets": [
+    {
+      "name": "_base",
+      "hidden": true,
+      "description": "Common settings for every cutils preset: out-of-source build under build/<preset-name>, compile_commands.json emitted for clangd, tests enabled. The generator is intentionally left unset so CMake uses its platform default (Unix Makefiles on Linux); both Make and Ninja emit compile_commands.json. Set a generator in CMakeUserPresets.json to override.",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "BUILD_TESTING": "ON"
+      }
+    },
+    {
+      "name": "pthread-debug",
+      "inherits": "_base",
+      "description": "Host pthread flavor, Debug. Runs under ctest on a hosted libc + pthreads system.",
+      "cacheVariables": {
+        "CUTILS_PLATFORM_TYPE": "pthread",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "pthread-release",
+      "inherits": "_base",
+      "description": "Host pthread flavor, Release.",
+      "cacheVariables": {
+        "CUTILS_PLATFORM_TYPE": "pthread",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "c11-debug",
+      "inherits": "_base",
+      "description": "Host C11-threads flavor, Debug. Calls into pthread underneath.",
+      "cacheVariables": {
+        "CUTILS_PLATFORM_TYPE": "c11",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "c11-release",
+      "inherits": "_base",
+      "description": "Host C11-threads flavor, Release.",
+      "cacheVariables": {
+        "CUTILS_PLATFORM_TYPE": "c11",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "freertos-debug",
+      "inherits": "_base",
+      "description": "FreeRTOS/M7 cross-build for the QEMU mps2-an500 (Cortex-M7) embtest_runner, Debug. Requires the arm-none-eabi-* bare-metal toolchain and qemu-system-arm on PATH (see cmake/arm-none-eabi.cmake). Fetches FreeRTOS-Kernel via FetchContent (CUTILS_FREERTOS_SOURCE=fetch).",
+      "toolchainFile": "${sourceDir}/cmake/arm-none-eabi.cmake",
+      "cacheVariables": {
+        "CUTILS_PLATFORM_TYPE": "freertos",
+        "CUTILS_FREERTOS_PORT": "GCC_ARM_CM7",
+        "CUTILS_FREERTOS_SOURCE": "fetch",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "freertos-release",
+      "inherits": "freertos-debug",
+      "description": "FreeRTOS/M7 QEMU target, Release.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "pthread-debug",    "configurePreset": "pthread-debug" },
+    { "name": "pthread-release",  "configurePreset": "pthread-release" },
+    { "name": "c11-debug",        "configurePreset": "c11-debug" },
+    { "name": "c11-release",     "configurePreset": "c11-release" },
+    { "name": "freertos-debug",   "configurePreset": "freertos-debug" },
+    { "name": "freertos-release", "configurePreset": "freertos-release" }
+  ],
+  "testPresets": [
+    {
+      "name": "pthread-debug",
+      "configurePreset": "pthread-debug",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "freertos-debug",
+      "configurePreset": "freertos-debug",
+      "output": { "outputOnFailure": true }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,38 @@ cmake -G "Your generator of choice" ..
 
 You can then build the individual targets based on your generator.
 
+### Presets (recommended)
+
+`CMakePresets.json` defines first-class configure/build/test presets for each
+platform flavor with Debug/Release splits, and always emits
+`compile_commands.json` (for clangd/IDE indexing):
+
+| preset              | platform | notes                                                                           |
+| ------------------- | -------- | ------------------------------------------------------------------------------ |
+| `pthread-debug`     | pthread  | host (Linux/macOS), runs under ctest                                          |
+| `pthread-release`   | pthread  | host, optimized                                                              |
+| `c11-debug`         | c11      | host C11 threads (calls into pthread)                                        |
+| `c11-release`       | c11      | host, optimized                                                             |
+| `freertos-debug`    | freertos | M7 QEMU (`mps2-an500`) cross-build; needs arm-none-eabi toolchain + `qemu-system-arm` |
+| `freertos-release`  | freertos | M7 QEMU, optimized                                                          |
+
+```
+# configure + build + test the host pthread flavor
+cmake --preset pthread-debug
+cmake --build --preset pthread-debug
+ctest --preset pthread-debug
+
+# FreeRTOS/M7 QEMU target (cross toolchain + qemu-system-arm on PATH)
+cmake --preset freertos-debug
+cmake --build --preset freertos-debug
+ctest --preset freertos-debug
+```
+
+Build dirs land under `build/<preset-name>/`. `CMAKE_EXPORT_COMPILE_COMMANDS`
+is set in `CMakeLists.txt`, so `compile_commands.json` is generated in each
+build dir for Make/Ninja generators (it is gitignored). Keep personal overrides
+in `CMakeUserPresets.json` (gitignored, not committed).
+
 ### Docs
 
 Look throught the [wiki](https://github.com/KartikAiyer/cutils/wiki) to learn more about how to use the utilities.


### PR DESCRIPTION
Closes #20.

## What

Adds first-class CMake preset support and guarantees `compile_commands.json` is generated for clangd/IDE indexing.

- **`CMakeLists.txt`** — `cmake_minimum_required` 3.14 → 3.21; `set(CMAKE_EXPORT_COMPILE_COMMANDS ON)` after `project()`.
- **`CMakePresets.json`** (new, schema v3) — `_base` hidden preset + pthread / c11 / freertos × Debug/Release configure + build + test presets. The freertos presets use the v3 `toolchainFile` field for `cmake/arm-none-eabi.cmake` and pin `GCC_ARM_CM7` + `CUTILS_FREERTOS_SOURCE=fetch`, so the M7/QEMU `embtest_runner` builds and registers for ctest out of the box.
- **`.gitignore`** — `CMakeUserPresets.json` (committed `CMakePresets.json` is the shared contract; user overrides stay local, per CMake convention).
- **`README.md`** — new "Presets (recommended)" section documenting `cmake --preset ...` as the canonical build entry point.

## Why v3 presets and not v4

The issue asked whether preset **v4** would offer better features than the **v3** proposed in the ticket. Conclusion: **stay on v3.** v4's headline addition is the `include` field (splitting presets across multiple files) plus `resolvePackageReferences` for vcpkg/conan — neither is useful for a 6-preset project with no package manager. v3 already gives us the `toolchainFile` field, which is exactly what makes the freertos presets clean instead of stuffing `CMAKE_TOOLCHAIN_FILE` into `cacheVariables`. v4 would raise the consumer CMake floor from 3.21 → 3.23 for zero concrete benefit here; a later upgrade is a one-line change if we ever split presets into separate files.

## Notes

- Generator is intentionally left unset in `_base` so CMake uses the platform default (Unix Makefiles on Linux). Both Make and Ninja emit `compile_commands.json`, so this keeps presets working out-of-the-box whether or not Ninja is installed. (The issue's sketch pinned Ninja, which would have failed on hosts without it.)
- Bumping `cmake_minimum_required` 3.14 → 3.21 is the floor v3 presets require (toolchainFile, testPresets). Flagging in case any downstream consumer is pinned to an older CMake.

## Verification

| preset | configure | build | test |
|---|---|---|---|
| pthread-debug | ✓ | ✓ | 10/10 ctest pass |
| pthread-release | ✓ | ✓ (-O3 confirmed) | — |
| c11-debug | ✓ | ✓ | — |
| c11-release | ✓ (Release) | — | — |
| freertos-debug | ✓ (FetchContent) | ✓ `embtest_runner` | QEMU 1/1 ctest pass |
| freertos-release | ✓ (Release) | — | — |

Refs: #11 (FreeRTOS/M7 QEMU port — presets land the `embtest_runner` build path as a first-class preset).