### PR TITLE
feat(#22): make pthread/c11 scheduling policy configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,19 @@ set(CUTILS_FREERTOS_SOURCE
 set_property(CACHE CUTILS_FREERTOS_SOURCE PROPERTY STRINGS fetch external)
 set(CUTILS_SUPPORTED_FREERTOS_SOURCE fetch external)
 
+# pthread/c11 scheduling policy. SCHED_OTHER (the default) is the host/CI
+# default: it runs unprivileged but exposes a 0..0 priority range, so
+# CUTILS_TASK_PRIORITY_* collapse to 0 and .priority is a no-op. The real-time
+# policies SCHED_FIFO/SCHED_RR expose a 1..99 range and make .priority real,
+# but on Linux require CAP_SYS_NICE — intended for the embedded-Linux (e.g.
+# PREEMPT_RT) production target, not host dev. See issue #22.
+set(CUTILS_PTHREAD_SCHED_POLICY
+    SCHED_OTHER
+    CACHE STRING "pthread/c11 scheduling policy (SCHED_OTHER | SCHED_FIFO | SCHED_RR)"
+)
+set_property(CACHE CUTILS_PTHREAD_SCHED_POLICY PROPERTY STRINGS SCHED_OTHER SCHED_FIFO SCHED_RR)
+set(CUTILS_SUPPORTED_PTHREAD_SCHED_POLICY SCHED_OTHER SCHED_FIFO SCHED_RR)
+
 # cmake-format: off
 if(NOT CUTILS_PLATFORM_TYPE IN_LIST CUTILS_SUPPORTED_PLATFORM_TYPES)
   message(FATAL_ERROR "CUTILS_PLATFORM_TYPE must be 'pthread' or 'c11' or 'freertos, got '${CUTILS_PLATFORM_TYPE}'")
@@ -64,6 +77,14 @@ if(CUTILS_PLATFORM_TYPE STREQUAL freertos)
     if(NOT DEFINED CUTILS_FREERTOS_PORT)
       message(FATAL_ERROR "You must provide CUTILS_FREERTOS_PORT, see FreeRTOS portable/CMakeLists.txt")
     endif()
+  endif()
+endif()
+
+if(CUTILS_PLATFORM_TYPE STREQUAL pthread OR CUTILS_PLATFORM_TYPE STREQUAL c11)
+  if(NOT CUTILS_PTHREAD_SCHED_POLICY IN_LIST CUTILS_SUPPORTED_PTHREAD_SCHED_POLICY)
+    message(FATAL_ERROR
+            "CUTILS_PTHREAD_SCHED_POLICY must be 'SCHED_OTHER', 'SCHED_FIFO' or 'SCHED_RR',"
+            " got '${CUTILS_PTHREAD_SCHED_POLICY}'")
   endif()
 endif()
 # cmake-format: on

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,6 +31,14 @@
       }
     },
     {
+      "name": "pthread-rt-debug",
+      "inherits": "pthread-debug",
+      "description": "Host pthread flavor with a real-time scheduling policy (SCHED_RR), Debug. Exposes the real 1..99 priority range so task_create_params_t::priority is honored via PTHREAD_EXPLICIT_SCHED — but on Linux this requires CAP_SYS_NICE (run as root, or grant the capability). Intended for the embedded-Linux (e.g. PREEMPT_RT) production target, not unprivileged host dev/CI; ctest under this preset will EPERM/segfault without privilege.",
+      "cacheVariables": {
+        "CUTILS_PTHREAD_SCHED_POLICY": "SCHED_RR"
+      }
+    },
+    {
       "name": "c11-debug",
       "inherits": "_base",
       "description": "Host C11-threads flavor, Debug. Calls into pthread underneath.",
@@ -72,6 +80,7 @@
   "buildPresets": [
     { "name": "pthread-debug",    "configurePreset": "pthread-debug" },
     { "name": "pthread-release",  "configurePreset": "pthread-release" },
+    { "name": "pthread-rt-debug", "configurePreset": "pthread-rt-debug" },
     { "name": "c11-debug",        "configurePreset": "c11-debug" },
     { "name": "c11-release",     "configurePreset": "c11-release" },
     { "name": "freertos-debug",   "configurePreset": "freertos-debug" },
@@ -81,6 +90,12 @@
     {
       "name": "pthread-debug",
       "configurePreset": "pthread-debug",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "pthread-rt-debug",
+      "configurePreset": "pthread-rt-debug",
+      "description": "Real-time (SCHED_RR) pthread tests. Requires CAP_SYS_NICE; will EPERM/segfault unprivileged.",
       "output": { "outputOnFailure": true }
     },
     {

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ platform flavor with Debug/Release splits, and always emits
 | ------------------- | -------- | ------------------------------------------------------------------------------ |
 | `pthread-debug`     | pthread  | host (Linux/macOS), runs under ctest                                          |
 | `pthread-release`   | pthread  | host, optimized                                                              |
+| `pthread-rt-debug`  | pthread  | real-time (`SCHED_RR`); needs `CAP_SYS_NICE` — production embedded-Linux target |
 | `c11-debug`         | c11      | host C11 threads (calls into pthread)                                        |
 | `c11-release`       | c11      | host, optimized                                                             |
 | `freertos-debug`    | freertos | M7 QEMU (`mps2-an500`) cross-build; needs arm-none-eabi toolchain + `qemu-system-arm` |
@@ -52,6 +53,39 @@ Build dirs land under `build/<preset-name>/`. `CMAKE_EXPORT_COMPILE_COMMANDS`
 is set in `CMakeLists.txt`, so `compile_commands.json` is generated in each
 build dir for Make/Ninja generators (it is gitignored). Keep personal overrides
 in `CMakeUserPresets.json` (gitignored, not committed).
+
+### Scheduling policy & task priorities
+
+The pthread/c11 ports select their POSIX scheduling policy via the
+`CUTILS_PTHREAD_SCHED_POLICY` cache variable (default `SCHED_OTHER`). This
+single knob drives both the `CUTILS_TASK_PRIORITY_*` range and whether
+`task_new_static()` takes explicit control of thread scheduling:
+
+| policy        | priority range | `.priority` honored? | requires privilege?            |
+| ------------- | -------------- | ------------------- | ------------------------------ |
+| `SCHED_OTHER` | 0..0           | no (no-op)          | no — host/CI default           |
+| `SCHED_FIFO`  | 1..99          | yes                 | yes (`CAP_SYS_NICE` on Linux)  |
+| `SCHED_RR`    | 1..99          | yes                 | yes (`CAP_SYS_NICE` on Linux)  |
+
+- Under `SCHED_OTHER` (the default, used by `pthread-debug`/`c11-debug`),
+  `sched_get_priority_{min,max}` are both `0`, so every `CUTILS_TASK_PRIORITY_*`
+  collapses to `0` and `task_create_params_t::priority` is silently ignored.
+  `task_new_static()` uses `PTHREAD_INHERIT_SCHED`, so the build runs
+  unprivileged. The abstraction here is a host convenience, not a real
+  scheduler — this is what keeps the host `ctest` suites green without root.
+- Under `SCHED_FIFO`/`SCHED_RR` (e.g. the `pthread-rt-debug` preset),
+  priorities are real and `.priority` is applied via `PTHREAD_EXPLICIT_SCHED`,
+  which on Linux requires `CAP_SYS_NICE`. Intended for the embedded-Linux
+  (e.g. PREEMPT_RT) production target; `pthread_create()` returns `EPERM`
+  without the capability.
+- The FreeRTOS port is where priorities are fully real with no privilege
+  requirement.
+
+Override at configure time, e.g.:
+
+```
+cmake --preset pthread-debug -DCUTILS_PTHREAD_SCHED_POLICY=SCHED_FIFO
+```
 
 ### Docs
 

--- a/inc/cutils/c11/c11threads.h
+++ b/inc/cutils/c11/c11threads.h
@@ -35,7 +35,19 @@
 #include <time.h>
 
 #define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
-#define SCHEDULING_POLICY (SCHED_OTHER)
+
+/* Scheduling policy for the c11 port (which calls into pthread underneath).
+ * Configurable at CMake time via CUTILS_PTHREAD_SCHED_POLICY (default
+ * SCHED_OTHER). Same priority-abstraction contract as the pthread port: under
+ * SCHED_OTHER the CUTILS_TASK_PRIORITY_* range is 0..0, .priority is a no-op
+ * and thrd_create_ex() inherits the parent's scheduling (host/CI, runs
+ * unprivileged); under SCHED_FIFO/SCHED_RR priorities are real (1..99) via
+ * PTHREAD_EXPLICIT_SCHED, which requires CAP_SYS_NICE on Linux — intended for
+ * the embedded-Linux production target. See issue #22. */
+#ifndef CUTILS_PTHREAD_SCHED_POLICY
+#define CUTILS_PTHREAD_SCHED_POLICY SCHED_OTHER
+#endif
+#define SCHEDULING_POLICY (CUTILS_PTHREAD_SCHED_POLICY)
 
 #ifdef __APPLE__
 /* Darwin doesn't implement timed mutexes currently */
@@ -91,6 +103,12 @@ static inline int thrd_create_ex(thrd_t *thr,
 
   int rval = pthread_attr_getstacksize(&attr, &min_stack_size);
   CHECK_RUN(!rval, pthread_attr_destroy(&attr); return rval, "Failed to query minimum stack size");
+  /* Only real-time policies expose a non-trivial priority range; gate
+   * PTHREAD_EXPLICIT_SCHED on SCHED_FIFO/SCHED_RR (needs CAP_SYS_NICE on
+   * Linux). Under the default SCHED_OTHER, .priority is a no-op and we inherit
+   * the parent's scheduling so the build runs unprivileged. See issue #22. */
+#if CUTILS_PTHREAD_SCHED_POLICY == SCHED_FIFO || \
+    CUTILS_PTHREAD_SCHED_POLICY == SCHED_RR
   rval = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
   CHECK_RUN(!rval, pthread_attr_destroy(&attr); return rval, "Failed to set scheduling parameter");
   rval = pthread_attr_setschedpolicy(&attr, SCHEDULING_POLICY);
@@ -99,6 +117,12 @@ static inline int thrd_create_ex(thrd_t *thr,
   rval = pthread_attr_setschedparam(&attr, &param);
   CHECK_RUN(!rval, pthread_attr_destroy(&attr);
             return rval, "Failed to set priority to %d", param.sched_priority);
+#else
+  /* SCHED_OTHER: priority range is 0..0, so .priority is a no-op. Inherit the
+   * creating thread's scheduling to avoid the CAP_SYS_NICE requirement. */
+  rval = pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
+  CHECK_RUN(!rval, pthread_attr_destroy(&attr); return rval, "Failed to set inherit scheduling");
+#endif
   if (stack && stack_size >= min_stack_size) {
     rval = pthread_attr_setstackaddr(&attr, stack);
     CHECK_RUN(!rval, pthread_attr_destroy(&attr);

--- a/inc/cutils/pthread/task.h
+++ b/inc/cutils/pthread/task.h
@@ -27,7 +27,32 @@
 #include <cutils/os_types.h>
 #include <pthread.h>
 
-#define SCHEDULING_POLICY (SCHED_OTHER)
+/**
+ * @brief Scheduling policy for the pthread port.
+ *
+ * Configurable at CMake time via CUTILS_PTHREAD_SCHED_POLICY (default
+ * SCHED_OTHER). This single knob drives both the CUTILS_TASK_PRIORITY_*
+ * range below and whether task_new_static() takes explicit control of thread
+ * scheduling.
+ *
+ * Priority-abstraction contract (Linux):
+ * - SCHED_OTHER (default): sched_get_priority_{min,max} == 0, so every
+ *   CUTILS_TASK_PRIORITY_* collapses to 0 and task_create_params_t::priority
+ *   is a no-op. task_new_static() uses PTHREAD_INHERIT_SCHED, so the build
+ *   runs unprivileged — the host/CI path. The abstraction is a host
+ *   convenience here, not a real scheduler.
+ * - SCHED_FIFO / SCHED_RR: 1..99 priority range; priorities are real and
+ *   .priority is honored via PTHREAD_EXPLICIT_SCHED. Requires CAP_SYS_NICE
+ *   (root), intended for the embedded-Linux (e.g. PREEMPT_RT) production
+ *   target; pthread_create() returns EPERM without it.
+ * - The FreeRTOS port is where priorities are fully real with no privilege.
+ *
+ * See issue #22.
+ */
+#ifndef CUTILS_PTHREAD_SCHED_POLICY
+#define CUTILS_PTHREAD_SCHED_POLICY SCHED_OTHER
+#endif
+#define SCHEDULING_POLICY (CUTILS_PTHREAD_SCHED_POLICY)
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/c11/CMakeLists.txt
+++ b/src/c11/CMakeLists.txt
@@ -9,6 +9,6 @@ add_library(platform_abstraction STATIC "${PLATFORM_HEADER_LIST}" "${HEADER_LIST
 set_target_properties(platform_abstraction PROPERTIES LINKER_LANGUAGE C)
 target_compile_options(platform_abstraction PUBLIC -std=gnu11)
 target_compile_features(platform_abstraction PUBLIC c_std_11)
-target_compile_definitions(platform_abstraction PUBLIC -D_GNU_SOURCE)
+target_compile_definitions(platform_abstraction PUBLIC -D_GNU_SOURCE CUTILS_PTHREAD_SCHED_POLICY=${CUTILS_PTHREAD_SCHED_POLICY})
 target_link_libraries(platform_abstraction ${CMAKE_THREAD_LIBS_INIT} logger_basic)
 target_include_directories(platform_abstraction PUBLIC ${API_INCLUDES})

--- a/src/pthread/CMakeLists.txt
+++ b/src/pthread/CMakeLists.txt
@@ -8,6 +8,6 @@ add_library(platform_abstraction STATIC "${PLATFORM_HEADER_LIST}" "${HEADER_LIST
                                         "${PLATFORM_SOURCES}")
 set_target_properties(platform_abstraction PROPERTIES LINKER_LANGUAGE C)
 target_compile_features(platform_abstraction PUBLIC c_std_11)
-
+target_compile_definitions(platform_abstraction PUBLIC CUTILS_PTHREAD_SCHED_POLICY=${CUTILS_PTHREAD_SCHED_POLICY})
 target_link_libraries(platform_abstraction ${CMAKE_THREAD_LIBS_INIT} logger_basic)
 target_include_directories(platform_abstraction PUBLIC ${API_INCLUDES})

--- a/src/pthread/task.c
+++ b/src/pthread/task.c
@@ -24,7 +24,6 @@
 
 #include <cutils/logger.h>
 #include <cutils/task.h>
-#include <errno.h>
 #include <pthread.h>
 #include <string.h>
 
@@ -57,10 +56,13 @@ task_t *task_new_static(task_create_params_t *create_params) {
     int rval = pthread_attr_getstacksize(&attr, &min_stack_size);
     CHECK_RUN(!rval, pthread_attr_destroy(&attr);
               return retval, "Failed to query minimum stack size");
-    /* Explicit scheduling (policy + priority) requires CAP_SYS_NICE on Linux.
-     * Unprivileged callers will see pthread_create() fail with EPERM below; we
-     * then retry once with PTHREAD_INHERIT_SCHED, which for SCHED_OTHER yields
-     * the same prio-0 thread the explicit path would have produced. */
+    /* Only real-time policies (SCHED_FIFO/SCHED_RR) expose a non-trivial
+     * priority range, so only they take explicit control of thread scheduling.
+     * On Linux that requires CAP_SYS_NICE; under the default SCHED_OTHER there
+     * is no range (0..0), .priority is a no-op, and we inherit the parent's
+     * scheduling so the build runs unprivileged. See issue #22. */
+#if CUTILS_PTHREAD_SCHED_POLICY == SCHED_FIFO || \
+    CUTILS_PTHREAD_SCHED_POLICY == SCHED_RR
     rval = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
     CHECK_RUN(!rval, pthread_attr_destroy(&attr);
               return retval, "Failed to set scheduling parameter");
@@ -70,6 +72,13 @@ task_t *task_new_static(task_create_params_t *create_params) {
     rval = pthread_attr_setschedparam(&attr, &param);
     CHECK_RUN(!rval, pthread_attr_destroy(&attr);
               return retval, "Failed to set priority to %d", param.sched_priority);
+#else
+    /* SCHED_OTHER: priority range is 0..0, so .priority is a no-op. Inherit
+     * the creating thread's scheduling to avoid the CAP_SYS_NICE requirement. */
+    rval = pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
+    CHECK_RUN(!rval, pthread_attr_destroy(&attr);
+              return retval, "Failed to set inherit scheduling");
+#endif
     if (create_params->stack && create_params->stack_size >= min_stack_size) {
       rval = pthread_attr_setstack(&attr, create_params->stack, create_params->stack_size);
       CHECK_RUN(!rval, pthread_attr_destroy(&attr);
@@ -80,19 +89,6 @@ task_t *task_new_static(task_create_params_t *create_params) {
     create_params->task->func = create_params->func;
 
     int res = pthread_create(&create_params->task->task, &attr, task_runner, create_params->task);
-    if (res == EPERM) {
-      /* PTHREAD_EXPLICIT_SCHED needs CAP_SYS_NICE. Fall back to the platform
-       * default scheduling (inherited from the creating thread). */
-      CLOG("task_new_static: pthread_create returned EPERM under PTHREAD_EXPLICIT_SCHED for "
-           "'%s'; retrying with PTHREAD_INHERIT_SCHED",
-           create_params->label ? create_params->label : "(null)");
-      pthread_attr_destroy(&attr);
-      pthread_attr_init(&attr);
-      if (create_params->stack && create_params->stack_size >= min_stack_size) {
-        pthread_attr_setstack(&attr, create_params->stack, create_params->stack_size);
-      }
-      res = pthread_create(&create_params->task->task, &attr, task_runner, create_params->task);
-    }
     pthread_attr_destroy(&attr);
 
     create_params->task->sanity = TASK_SANITY;


### PR DESCRIPTION
## Summary

Decouples the scheduling policy choice from the `PTHREAD_EXPLICIT_SCHED`
decision and makes both configurable, per #22.

- New **`CUTILS_PTHREAD_SCHED_POLICY`** cache variable (default
  `SCHED_OTHER`), with validation against `SCHED_OTHER` / `SCHED_FIFO` /
  `SCHED_RR`.
- The pthread and c11 port headers derive `SCHEDULING_POLICY` from this
  knob instead of the hardcoded `SCHED_OTHER`.
- `task_new_static()` (pthread) and `thrd_create_ex()` (c11) gate
  `PTHREAD_EXPLICIT_SCHED` on the real-time policies (`SCHED_FIFO` /
  `SCHED_RR`). Under the default `SCHED_OTHER` they use
  `PTHREAD_INHERIT_SCHED`, which needs **no** `CAP_SYS_NICE` — so host
  dev/CI runs unprivileged and the previously unconditional `EPERM` on
  `pthread_create` is gone. Under an RT policy the full 1..99 priority
  range is real and `.priority` is honored, intended for the
  embedded-Linux (e.g. PREEMPT_RT) production target.
- New **`pthread-rt-debug`** preset (`SCHED_RR`) for the production
  embedded-Linux case; documented that it requires `CAP_SYS_NICE`.
- Priority-abstraction contract documented per policy in the port
  headers and README.

This **supersedes the #19 band-aid** (the `EPERM`-retry fallback is
removed): under `SCHED_OTHER` the code no longer requests explicit
scheduling in the first place, so the root cause of #19 is gone rather
than papered over.

## Verification

- `cmake --preset pthread-debug` → build → `ctest`: **10/10 pass**
- `cmake --preset c11-debug` → build → `ctest`: **10/10 pass**
- `cmake --preset pthread-rt-debug` → build OK (RT/EXPLICIT_SCHED path)
- Preprocessor check confirms `task_new_static` selects
  `PTHREAD_INHERIT_SCHED` under `SCHED_OTHER` and
  `PTHREAD_EXPLICIT_SCHED` + `SCHEDULING_POLICY==SCHED_RR` under the RT
  preset.
- Negative config test: an invalid policy value `FATAL_ERROR`s as
  expected.

## Issue scope (#22)

- [x] `CUTILS_PTHREAD_SCHED_POLICY` cache variable (default `SCHED_OTHER`)
- [x] Port header consumes the selected policy instead of hardcoded `SCHED_OTHER`
- [x] `task_new_static` (pthread + c11) gates `PTHREAD_EXPLICIT_SCHED` on real-time policy; uses `PTHREAD_INHERIT_SCHED` for `SCHED_OTHER`
- [x] c11 port gets the same treatment
- [x] Preset surface for an RT-policy variant (coordinate with #20)
- [x] Documentation: priority-abstraction contract per policy
- [x] Resolves the #19 root cause (no more unconditional EPERM on host)

Closes #22.
Refs: #19 (superseded), #12 (builds on), #20 (preset coordination).