### PR TITLE
fix(#23): replace deprecated pthread APIs and silence cast warnings in c11 port

### DIFF
--- a/inc/cutils/c11/c11threads.h
+++ b/inc/cutils/c11/c11threads.h
@@ -78,11 +78,33 @@ enum { thrd_success, thrd_timedout, thrd_busy, thrd_error, thrd_nomem };
 
 /* ---- thread management ---- */
 
+/* Internal bridge from our int-returning thrd_start_t to the void*-returning
+ * start routine pthread_create expects. Casting between incompatible function
+ * pointer types is technically UB and trips -Wcast-function-type; thrd_join
+ * reinterprets the return value back to int anyway, so the cast is benign on
+ * every ABI we target. Isolate it here with the warning silenced locally so
+ * neither thrd_create nor thrd_create_ex exposes the cast at its call site.
+ * See issue #23. */
+static inline int c11threads_pthread_create(thrd_t *thr,
+                                            const pthread_attr_t *attr,
+                                            thrd_start_t func,
+                                            void *arg) {
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
+  void *(*start)(void *) = (void *(*)(void *))func;
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+  return pthread_create(thr, attr, start, arg);
+}
+
 static inline int thrd_create(thrd_t *thr, thrd_start_t func, void *arg) {
   pthread_attr_t attr = {0};
   pthread_attr_init(&attr);
 
-  int res = pthread_create(thr, &attr, (void *(*)(void *))func, arg);
+  int res = c11threads_pthread_create(thr, &attr, func, arg);
   if (res == 0) {
     return thrd_success;
   }
@@ -100,6 +122,11 @@ static inline int thrd_create_ex(thrd_t *thr,
   pthread_attr_t attr = {0};
   size_t min_stack_size = 0;
   pthread_attr_init(&attr);
+  /* label is stored by the task layer (see task_get_current_name in
+   * src/c11/task.c, which reads a thread-local task pointer); thread naming
+   * via pthread_setname_np was removed for portability since it is a glibc
+   * Linux-only (_GNU_SOURCE) extension. See issue #23. */
+  (void)label;
 
   int rval = pthread_attr_getstacksize(&attr, &min_stack_size);
   CHECK_RUN(!rval, pthread_attr_destroy(&attr); return rval, "Failed to query minimum stack size");
@@ -124,21 +151,18 @@ static inline int thrd_create_ex(thrd_t *thr,
   CHECK_RUN(!rval, pthread_attr_destroy(&attr); return rval, "Failed to set inherit scheduling");
 #endif
   if (stack && stack_size >= min_stack_size) {
-    rval = pthread_attr_setstackaddr(&attr, stack);
+    rval = pthread_attr_setstack(&attr, stack, stack_size);
     CHECK_RUN(!rval, pthread_attr_destroy(&attr);
-              return rval, "Failed to set stack address", stack);
-    rval = pthread_attr_setstacksize(&attr, stack_size);
-    CHECK_RUN(!rval, pthread_attr_destroy(&attr); return rval, "Failed to set stack size");
+              return rval, "Failed to set stack", stack);
   }
   CHECK_RUN(!rval, pthread_attr_destroy(&attr);
             return rval,
                    "Failed to set scheduling priority between (%d, %d)",
                    sched_get_priority_min(SCHEDULING_POLICY),
                    sched_get_priority_max(SCHEDULING_POLICY));
-  int res = pthread_create(thr, &attr, (void *(*)(void *))func, arg);
+  int res = c11threads_pthread_create(thr, &attr, func, arg);
   pthread_attr_destroy(&attr);
   if (res == 0) {
-    pthread_setname_np(*thr, label);
     return thrd_success;
   } else {
     return thrd_error;


### PR DESCRIPTION
Closes #23.

Implements the three remediation items from #23, all confined to `inc/cutils/c11/c11threads.h`:

### 1. Replace deprecated `pthread_attr_setstackaddr`/`setstacksize`
Swapped the obsolete two-call sequence for the single non-deprecated [`pthread_attr_setstack`](https://man7.org/linux/man-pages/en/3/pthread_attr_setstack.3.html) — matching the form already used by the pthread port (`src/pthread/task.c`). This removes the `-Wdeprecated-declarations` warning from the header **and** the matching linker warning emitted from `src/c11/task.c` (which inlines `thrd_create_ex`).

### 2. Silence `-Wcast-function-type` (option a — shim)
Added a `static inline c11threads_pthread_create` helper that centralizes the `int(*)(void*)` → `void*(*)(void*)` cast with `-Wcast-function-type` silenced locally via a `#pragma GCC diagnostic push/pop`. `thrd_create` and `thrd_create_ex` now call the shim, so neither call site exposes the cast — smallest blast radius, no behavior change.

### 3. Remove `pthread_setname_np` (option B)
Dropped the unconditional `pthread_setname_np(*thr, label)` call (glibc Linux-only, needs `_GNU_SOURCE`). Thread naming is already handled portably by the task layer — `task_get_current_name` in `src/c11/task.c` reads a thread-local `task_t*` whose `label` is populated by `task_new_static` — mirroring what #14 did for `task_get_current_name`. The public `thrd_create_ex` signature is unchanged; `label` is now marked `(void)label` since the c11threads layer no longer consumes it.

## Acceptance verification

Repro from the issue:
```bash
rm -rf build-c11 && cmake -B build-c11 -S . \
    -DCUTILS_PLATFORM_TYPE=c11 -DCMAKE_C_FLAGS="-Wall -Wextra"
cmake --build build-c11 2>&1 | grep 'warning:' | sort -u
```

**Targeted warning classes — eliminated from `inc/` and `src/`:**
- ✅ `-Wdeprecated-declarations` (`pthread_attr_setstackaddr`) — gone
- ✅ `-Wcast-function-type` at both `pthread_create` sites — gone
- ✅ `pthread_setname_np` portability concern — gone (removed)

**ctest:** 10/10 passing (no regression vs. master; the 3 pre-existing segfaults noted in #23 are already resolved on master).

**No API break:** the public `thrd_create` / `thrd_create_ex` signatures are unchanged; one deprecated implementation detail was removed.

## Out of scope

Pre-existing `-Wunused-parameter` warnings remain in `src/` (e.g. `asyncio.c`, `logger.c`, `state_machine.c`, `state_event_loop.c`) and one in `c11threads.h` for `priority` under the default `SCHED_OTHER` policy (introduced by #22). These are unrelated to the c11 port and not part of #23's remediation — left for a separate cleanup.