### PR TITLE
fix(#32): silence remaining -Wall/-Wextra warnings in src/ and inc/

### DIFF
--- a/inc/cutils/c11/c11threads.h
+++ b/inc/cutils/c11/c11threads.h
@@ -147,6 +147,7 @@ static inline int thrd_create_ex(thrd_t *thr,
 #else
   /* SCHED_OTHER: priority range is 0..0, so .priority is a no-op. Inherit the
    * creating thread's scheduling to avoid the CAP_SYS_NICE requirement. */
+  (void)priority;
   rval = pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
   CHECK_RUN(!rval, pthread_attr_destroy(&attr); return rval, "Failed to set inherit scheduling");
 #endif

--- a/src/asyncio.c
+++ b/src/asyncio.c
@@ -60,6 +60,7 @@ static bool asyncio_start_rx_thread(asyncio_interface_instance_t *p_asyncio);
 
 static uint32_t
 asyncio_logger_prefix(logger_t *logger, void *client_data, char *string, uint32_t string_size) {
+  (void)client_data;
   uint32_t retval = 0;
   asyncio_interface_instance_t *p_asyncio =
       (asyncio_interface_instance_t *)((size_t)logger -
@@ -437,6 +438,7 @@ static void tx_f(void *arg1, void *arg2) {
 }
 
 static void rx_f(void *arg1, void *arg2) {
+  (void)arg2;
   uint8_t *p_buf = 0;
   size_t bytes_read = 0;
   asyncio_interface_instance_t *p_asyncio = (asyncio_interface_instance_t *)arg1;

--- a/src/c11/task.c
+++ b/src/c11/task.c
@@ -69,7 +69,10 @@ void task_destroy_static(task_t *task) {
     thrd_join(task->task, &res);
   }
 }
-bool task_start(task_t *task) { return true; }
+bool task_start(task_t *task) {
+  (void)task;
+  return true;
+}
 
 cutils_ticks_t task_get_ticks(void) {
   struct timespec res = {0};

--- a/src/logger.c
+++ b/src/logger.c
@@ -65,6 +65,8 @@ uint32_t logger_write_string(logger_t *p_logger,
 
 uint32_t
 SimpleLoggerPrefix(logger_t *p_logger, void *p_private, char *p_string, uint32_t string_size) {
+  (void)p_private;
+  (void)string_size;
   int size = 0;
   simple_logger_t *p_simple = (simple_logger_t *)p_logger;
 

--- a/src/pthread/task.c
+++ b/src/pthread/task.c
@@ -39,6 +39,7 @@ static void *task_runner(void *ctx) {
   pthread_setspecific(s_task_private_key, task);
   task->func(task->ctx);
   pthread_setspecific(s_task_private_key, NULL);
+  return NULL;
 }
 
 task_t *task_new_static(task_create_params_t *create_params) {
@@ -107,7 +108,10 @@ void task_destroy_static(task_t *task) {
     CUTILS_ASSERTF(!res, "Thread Join Failed");
   }
 }
-bool task_start(task_t *task) { return true; }
+bool task_start(task_t *task) {
+  (void)task;
+  return true;
+}
 
 cutils_ticks_t task_get_ticks(void) {
   struct timespec res = {0};

--- a/src/state_event_loop.c
+++ b/src/state_event_loop.c
@@ -158,6 +158,7 @@ bool state_event_loop_install_event_pre_proc(state_event_loop_t *event_loop,
 }
 
 void state_event_loop_exec_queue_f(void *arg1, void *arg2) {
+  (void)arg2;
   event_t *event = (event_t *)arg1;
   state_event_loop_t *event_loop = event->event_loop;
 

--- a/src/state_machine.c
+++ b/src/state_machine.c
@@ -34,6 +34,8 @@
 #define SM_DEFAULT_LOGGING (true)
 
 static uint32_t StateMachinePrefix(logger_t *logger, void *priv, char *str, uint32_t str_size) {
+  (void)logger;
+  (void)str_size;
   uint32_t retval = 0;
   state_machine_t *state_mac = (state_machine_t *)priv;
 

--- a/tests/asyncio_test.c
+++ b/tests/asyncio_test.c
@@ -130,6 +130,7 @@ static size_t validate_accumulator(testio_data_t *p_data) {
 }
 
 static size_t testio_read_f(asyncio_handle_t handle, uint8_t *p_rx_data_buf, uint32_t timeout) {
+  (void)p_rx_data_buf;
   size_t retval = 0;
   testio_data_t *p_data = (testio_data_t *)asyncio_get_private_data(handle);
   uint32_t act_flags = 0;
@@ -145,6 +146,7 @@ static size_t testio_write_f(asyncio_handle_t handle,
                              size_t tx_data_size,
                              uint8_t *p_tx_data_buf,
                              uint32_t timeout) {
+  (void)timeout;
   size_t retval = 0;
   testio_data_t *p_data = (testio_data_t *)asyncio_get_private_data(handle);
 
@@ -172,6 +174,7 @@ static size_t testio_tx_only_write_f(asyncio_handle_t handle,
                                      size_t tx_data_size,
                                      uint8_t *p_tx_data_buf,
                                      uint32_t timeout) {
+  (void)timeout;
   size_t retval = 0;
   // Just going to validate the data.
   testio_data_t *p_data = (testio_data_t *)asyncio_get_private_data(handle);
@@ -217,6 +220,8 @@ static bool send_random_payload(testio_data_t *p_data,
 }
 
 static void testio_rx_f(asyncio_handle_t h_asyncio, asyncio_message_t message, size_t size) {
+  (void)message;
+  (void)size;
 
   testio_data_t *p_data = (testio_data_t *)asyncio_get_private_data(h_asyncio);
 
@@ -280,6 +285,10 @@ static void asyncio_tx_only_notification_f(asyncio_tx_token_t token,
                                            asyncio_tx_send_status_e sendStatus,
                                            uint32_t sendSize,
                                            void *pPrivate) {
+  (void)token;
+  (void)sendStatus;
+  (void)sendSize;
+  (void)pPrivate;
   if (s_data.status == TestContinuing) {
     s_data.current_proc_packets++;
     event_flag_send(&s_data.evt, BUF_AVAIL_TO_READ);

--- a/tests/dispatch_queue_tests.c
+++ b/tests/dispatch_queue_tests.c
@@ -42,6 +42,7 @@ typedef struct {
 } action_data_t;
 
 static void action_1(void *arg1, void *arg2) {
+  (void)arg2;
   action_data_t *p_data = (action_data_t *)arg1;
   task_sleep(p_data->sleep_time);
   p_data->val = 1;
@@ -87,11 +88,13 @@ typedef struct {
 } task_action_test_data_t;
 
 static void lo_action(void *arg1, void *arg2) {
+  (void)arg2;
   task_action_test_data_t *p_data = (task_action_test_data_t *)arg1;
   p_data->val--;
 }
 
 static void hi_action(void *arg1, void *arg2) {
+  (void)arg2;
   task_action_test_data_t *p_data = (task_action_test_data_t *)arg1;
 
   TEST_ASSERT(p_data);
@@ -100,6 +103,7 @@ static void hi_action(void *arg1, void *arg2) {
 }
 
 static void medium_action(void *arg1, void *arg2) {
+  (void)arg2;
   task_action_test_data_t *p_data = (task_action_test_data_t *)arg1;
 
   TEST_ASSERT(p_data);

--- a/tests/klist_test.c
+++ b/tests/klist_test.c
@@ -32,6 +32,7 @@ struct test_obj {
 };
 
 static void count_up_f(KListElem *elem, ...) {
+  (void)elem;
   va_list args;
   va_start(args, elem);
   uint32_t *p_count = va_arg(args, uint32_t *);

--- a/tests/notifier_tests.c
+++ b/tests/notifier_tests.c
@@ -84,6 +84,7 @@ static posted_counts_t s_count_array[NOTIFIER_TEST_MAX_CATS];
 static test_notification_t *s_posted_array[NOTIFIER_TEST_MAX_POSTS];
 
 static void test_notifier_callback(notifier_block_t *block, uint32_t category, void *notif_data) {
+  (void)block;
   posted_counts_t *count_array = (posted_counts_t *)notif_data;
 
   count_array[category].count++;

--- a/tests/pool_tests.c
+++ b/tests/pool_tests.c
@@ -101,6 +101,8 @@ typedef struct _ref_count_test_t {
 static ref_count_test_t s_test_data = {0};
 
 static void test_destructor_f(void *mem, void *private) {
+  (void)mem;
+  (void)private;
   TEST_ASSERT_MESSAGE(s_test_data.total_count == 0, "Destructor called before References removed");
   s_test_data.total_count = (uint32_t)-1;
 }
@@ -251,6 +253,7 @@ static void launcher_action(void *ctx) {
 }
 
 static void destructor_fn(void *mem, void *private) {
+  (void)mem;
   pool_retain_test_data_t *p_test_data = (pool_retain_test_data_t *)private;
   p_test_data->result = POOL_RETAIN_TEST_SUCCESS;
 }

--- a/tests/queue_test.c
+++ b/tests/queue_test.c
@@ -60,7 +60,6 @@ static void freeListCanCreateWithAppropriateSize(void) {
 
 static void freeListCanAllocateAsManyAsAvailable(void) {
   KListHead *p_head = 0;
-  KListElem *p_alloc = NULL;
   for (uint32_t i = 0; i < s_fl_list->item_count; i++) {
     free_list_test_unit_t *item = (free_list_test_unit_t *)free_list_get(s_fl_list);
     TEST_ASSERT(item);

--- a/tests/state_event_loop_tests.c
+++ b/tests/state_event_loop_tests.c
@@ -80,6 +80,7 @@ typedef struct {
 } posted_counts_t;
 
 static void test_notifier_callback(notifier_block_t *block, uint32_t category, void *notif_data) {
+  (void)block;
   posted_counts_t *count_array = (posted_counts_t *)notif_data;
 
   count_array[category].count++;
@@ -114,11 +115,19 @@ static void test_state_init(state_machine_t *sm, state_t *state) {
   p_loop->init_count++;
 }
 
-static void test_state_enter(state_machine_t *sm, state_t *state) {}
+static void test_state_enter(state_machine_t *sm, state_t *state) {
+  (void)sm;
+  (void)state;
+}
 
-static void test_state_exit(state_machine_t *sm, state_t *state) {}
+static void test_state_exit(state_machine_t *sm, state_t *state) {
+  (void)sm;
+  (void)state;
+}
 
 static bool test_state_valid_event(state_machine_t *sm, state_t *state, void *evt) {
+  (void)sm;
+  (void)state;
   test_event_t *event = (test_event_t *)evt;
 
   if (event->base.event_id < TEST_MAX_EVENT_ID)
@@ -128,6 +137,7 @@ static bool test_state_valid_event(state_machine_t *sm, state_t *state, void *ev
 }
 
 static uint32_t test_state_handle_event(state_machine_t *sm, state_t *state, void *evt) {
+  (void)sm;
   uint32_t next_state = state->stateId;
   test_state_t *test_state = (test_state_t *)state;
   test_event_t *event = (test_event_t *)evt;


### PR DESCRIPTION
Closes #32.

Originally scoped to `src/` + `inc/` per #32; per follow-up the `tests/` warnings are now included too. After this, a clean **c11 or pthread** build under `-Wall -Wextra` is warning-free outside of `extern/embunit/` (upstream test harness, explicitly out of scope per #32).

## Changes

All confined to keeping public/callback signatures stable. The one substantive fix:

- **`src/pthread/task.c` — `-Wreturn-type` (the real bug):** `static void *task_runner(void *ctx)` fell off the end without a `return` statement. Falling off a non-void function is UB in C99+. Added `return NULL;`. This is the only non-cosmetic change in the PR.

The rest are mechanical `-Wunused-parameter` silencing via `(void)x;` (consistent with how #23 handled `label` in `c11threads.h`), plus one dead-local removal:

- **`inc/cutils/c11/c11threads.h`** — `priority` is only consumed in the `SCHED_FIFO`/`SCHED_RR` branch; under the default `SCHED_OTHER` (from #22) it is genuinely unused. Added `(void)priority;` in the `#else` arm.
- **`src/c11/task.c`**, **`src/pthread/task.c`** — `task` unused in the `task_start` stub.
- **`src/asyncio.c`** — `client_data` unused in `asyncio_logger_prefix`; `arg2` unused in `rx_f`.
- **`src/logger.c`** — `p_private` and `string_size` unused in `SimpleLoggerPrefix`.
- **`src/state_event_loop.c`** — `arg2` unused in `state_event_loop_exec_queue_f`.
- **`src/state_machine.c`** — `logger` and `str_size` unused in `StateMachinePrefix`.
- **`tests/asyncio_test.c`** — `p_rx_data_buf`, `timeout` (x2), `message`, `size`, and all four params of `asyncio_tx_only_notification_f`.
- **`tests/dispatch_queue_tests.c`** — `arg2` in `action_1`/`lo_action`/`hi_action`/`medium_action`.
- **`tests/notifier_tests.c`** — `block` in `test_notifier_callback`.
- **`tests/pool_tests.c`** — `mem`+`private` in `test_destructor_f`; `mem` in `destructor_fn` (`private` is used there).
- **`tests/state_event_loop_tests.c`** — `block` in `test_notifier_callback`; `sm`+`state` in `test_state_enter`/`exit`/`valid_event`; `sm` in `test_state_handle_event` (`state`+`evt` used).
- **`tests/klist_test.c`** — `elem` in `count_up_f`: it is the last named parameter required by `va_start`, so it cannot be removed; discarded with `(void)elem;`.
- **`tests/queue_test.c`** — `p_alloc` was a `-Wunused-variable` (dead local initialized to `NULL`, never read), so removed outright rather than cast.

No public API or callback signature changes.

## Verification

```bash
# c11 / pthread, -Wall -Wextra — zero warnings outside extern/embunit/
cmake --build build-c11     2>&1 | grep 'warning:' | grep -v '/extern/embunit/'   # (empty)
cmake --build build-pthread 2>&1 | grep 'warning:' | grep -v '/extern/embunit/'   # (empty)
```

**ctest:** 10/10 on pthread; 10/10 on c11. `asyncio_tests` is a threaded test with pre-existing intermittent flakiness under load (it passed 3/3 in isolation and 5/5 in the full suite here); every change in this PR is a pure no-op `(void)x;` cast or a dead-local removal, none of which can affect runtime behavior.

## Out of scope

- `extern/embunit/` — upstream test harness, explicitly out of scope per #32.

## Refs

- #32 — this ticket.
- #23 — c11 port cleanup (the bulk); PR #31.
- #22 — introduced `CUTILS_PTHREAD_SCHED_POLICY`, which left `priority` unused under the default `SCHED_OTHER`.