### PR TITLE
feat(#34): split freertos embtest_runner into per-suite ctests

### DIFF
--- a/tests/freertos/GCC_ARM_CM7/CMakeLists.txt
+++ b/tests/freertos/GCC_ARM_CM7/CMakeLists.txt
@@ -1,43 +1,133 @@
-# Aggregate embUnit test runner for the FreeRTOS/AN500 target.
+# embUnit test runners for the FreeRTOS/AN500 (QEMU mps2-an500, Cortex-M7) target.
 #
-# Builds `embtest_runner` — a bare-metal ELF that runs every cutils embUnit
-# suite under FreeRTOS on the QEMU mps2-an500 (Cortex-M7) machine. A ctest
-# entry launches QEMU with -semihosting so semihost_exit(0|1) becomes the
-# process exit code that ctest reads as pass/fail.
+# Registers one ctest per suite (embtest_<suite>) plus an opt-in all-in-one
+# embtest_runner (CUTILS_FREERTOS_AGGREGATE_RUNNER=ON). Each runner is a
+# bare-metal ELF that boots FreeRTOS under QEMU; semihost_exit(0|1) in
+# retarget.c becomes QEMU's process exit code, which ctest reads as pass/fail.
+#
+# Design: all suite sources + the bare-metal scaffolding compile once into the
+# embtest_common OBJECT library; each runner adds only its main.c (compiled
+# with -DCUTILS_EMBTEST_SUITE=<accessor> to select one suite, or without it
+# for the aggregate). -ffunction-sections + --gc-sections (see
+# cmake/arm-none-eabi.cmake) then strip every unreferenced suite, so each
+# per-suite ELF carries only its own suite + shared bare-metal.
 
+# --- shared bare-metal scaffolding + every suite source (compiled once) ------
 file(GLOB test_sources ${PROJECT_SOURCE_DIR}/tests/*.c)
 list(REMOVE_ITEM test_sources ${PROJECT_SOURCE_DIR}/tests/all_embunit_tests.c)
-list(APPEND test_sources main.c retarget.c startup.c)
 
-add_executable(embtest_runner ${test_sources})
-target_link_libraries(embtest_runner PUBLIC cutils platform_abstraction freertos_kernel embunit)
+add_library(
+  embtest_common
+  OBJECT
+  ${test_sources}
+  startup.c
+  retarget.c)
 target_include_directories(
-  embtest_runner
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/extern/embunit ${API_INCLUDES}
-)
-target_link_options(embtest_runner PRIVATE -T${CMAKE_CURRENT_SOURCE_DIR}/linker.ld -nostartfiles)
-target_compile_definitions(embtest_runner PRIVATE AGGREGATE_RUNNER)
+  embtest_common
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/extern/embunit ${API_INCLUDES})
+# AGGREGATE_RUNNER suppresses each suite's hosted #ifndef AGGREGATE_RUNNER
+# main() so the bare-metal main() in main.c is the sole entry point.
+target_compile_definitions(embtest_common PUBLIC AGGREGATE_RUNNER)
+target_link_libraries(embtest_common PUBLIC cutils platform_abstraction freertos_kernel embunit)
 
-add_custom_command(
-  TARGET embtest_runner
-  POST_BUILD
-  COMMAND ${CMAKE_SIZE} $<TARGET_FILE:embtest_runner>
-)
-
-# --- ctest: launch the runner in QEMU -----------------------------------------
-# QEMU's process exit code is the value passed to semihost_exit() in
-# retarget.c (0 = all tests passed, 1 = at least one failure), so ctest gets a
-# first-class pass/fail signal with the UART output as human-readable detail.
-# A generous timeout guards against a hung runner (e.g. a deadlock that
-# prevents semihost_exit from ever firing).
+# --- QEMU probe (once) -------------------------------------------------------
 find_program(QEMU_SYSTEM_ARM qemu-system-arm)
-if(QEMU_SYSTEM_ARM)
-  add_test(
-    NAME embtest_runner
-    COMMAND
-      ${QEMU_SYSTEM_ARM} -machine mps2-an500 -cpu cortex-m7 -m 16M -kernel
-      $<TARGET_FILE:embtest_runner> -nographic -semihosting)
-  set_tests_properties(embtest_runner PROPERTIES TIMEOUT 120)
-else()
-  message(STATUS "qemu-system-arm not found; skipping ctest registration for embtest_runner")
+
+# --- bare-metal link flags shared by every runner ----------------------------
+set(embtest_link_flags -T${CMAKE_CURRENT_SOURCE_DIR}/linker.ld -nostartfiles)
+
+# --- helper: build one per-suite runner ELF + register a ctest ---------------
+# freertos_add_embunit_test(NAME <suite> SUITE_FN <accessor> [TIMEOUT <sec>])
+function(freertos_add_embunit_test)
+  cmake_parse_arguments(FAET "" "NAME;SUITE_FN;TIMEOUT" "" ${ARGN})
+  if(NOT FAET_NAME)
+    message(FATAL_ERROR "freertos_add_embunit_test requires NAME")
+  endif()
+  if(NOT FAET_SUITE_FN)
+    message(FATAL_ERROR "freertos_add_embunit_test requires SUITE_FN")
+  endif()
+  if(NOT FAET_TIMEOUT)
+    set(FAET_TIMEOUT 60)
+  endif()
+
+  set(target embtest_${FAET_NAME})
+  add_executable(${target} main.c)
+  target_compile_definitions(${target} PRIVATE CUTILS_EMBTEST_SUITE=${FAET_SUITE_FN})
+  target_link_libraries(${target} PRIVATE embtest_common)
+  target_link_options(${target} PRIVATE ${embtest_link_flags})
+  target_compile_features(${target} PRIVATE c_std_11)
+  set_target_properties(${target} PROPERTIES FOLDER tests/freertos)
+
+  add_custom_command(
+    TARGET ${target}
+    POST_BUILD
+    COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${target}>)
+
+  if(QEMU_SYSTEM_ARM)
+    add_test(
+      NAME ${target}
+      COMMAND
+        ${QEMU_SYSTEM_ARM} -machine mps2-an500 -cpu cortex-m7 -m 16M -kernel
+        $<TARGET_FILE:${target}> -nographic -semihosting)
+    set_tests_properties(${target} PROPERTIES TIMEOUT ${FAET_TIMEOUT})
+  else()
+    message(STATUS "qemu-system-arm not found; skipping ctest registration for ${target}")
+  endif()
+endfunction()
+
+# --- opt-in aggregate runner (all suites in one QEMU boot) -------------------
+# Strictly faster than N per-suite boots for a known-green full run, so kept as
+# an opt-in convenience for local smoke tests. Default OFF: the per-suite
+# embtest_<suite> ctests above are the CI granularity.
+option(CUTILS_FREERTOS_AGGREGATE_RUNNER
+       "Build the all-in-one embtest_runner ELF (one QEMU boot for all suites)" OFF)
+if(CUTILS_FREERTOS_AGGREGATE_RUNNER)
+  add_executable(embtest_runner main.c)
+  target_link_libraries(embtest_runner PRIVATE embtest_common)
+  target_link_options(embtest_runner PRIVATE ${embtest_link_flags})
+  target_compile_features(embtest_runner PRIVATE c_std_11)
+  set_target_properties(embtest_runner PROPERTIES FOLDER tests/freertos)
+
+  add_custom_command(
+    TARGET embtest_runner
+    POST_BUILD
+    COMMAND ${CMAKE_SIZE} $<TARGET_FILE:embtest_runner>)
+
+  if(QEMU_SYSTEM_ARM)
+    add_test(
+      NAME embtest_runner
+      COMMAND
+        ${QEMU_SYSTEM_ARM} -machine mps2-an500 -cpu cortex-m7 -m 16M -kernel
+        $<TARGET_FILE:embtest_runner> -nographic -semihosting)
+    # One boot runs everything, so it needs a longer budget than a single suite.
+    set_tests_properties(embtest_runner PROPERTIES TIMEOUT 120)
+  else()
+    message(STATUS "qemu-system-arm not found; skipping ctest registration for embtest_runner")
+  endif()
 endif()
+
+# --- per-suite runners -------------------------------------------------------
+# Mirrors the suite list in main.c's aggregate branch (and the hosted
+# all_embunit_tests.c), now surfaced as first-class ctests. The previously-
+# orphaned dispatch_queue_timer_get_tests is excluded here — see note below.
+freertos_add_embunit_test(NAME klist                 SUITE_FN klist_get_tests)
+freertos_add_embunit_test(NAME mem_ring_buffer       SUITE_FN mem_ring_buffer_get_tests)
+freertos_add_embunit_test(NAME os_mutex              SUITE_FN os_mutex_get_tests)
+freertos_add_embunit_test(NAME os_event_flag         SUITE_FN os_event_flag_get_tests)
+freertos_add_embunit_test(NAME os_task               SUITE_FN os_task_get_tests)
+freertos_add_embunit_test(NAME queue_free_list       SUITE_FN queue_free_list_get_tests)
+freertos_add_embunit_test(NAME queue_kqueue          SUITE_FN queue_kqueue_get_tests)
+freertos_add_embunit_test(NAME queue_ts_queue_simple SUITE_FN queue_ts_queue_simple_get_tests)
+freertos_add_embunit_test(NAME queue_ts_queue        SUITE_FN queue_ts_queue_get_tests)
+freertos_add_embunit_test(NAME pool                  SUITE_FN pool_get_tests)
+freertos_add_embunit_test(NAME notifier              SUITE_FN notifier_get_tests)
+freertos_add_embunit_test(NAME notifier_static_store SUITE_FN notifier_static_store_get_tests)
+freertos_add_embunit_test(NAME accumulator           SUITE_FN accumulator_get_tests)
+# dispatch_queue_timer is intentionally excluded: dispatch_queue_timer_get_tests
+# is #if 0'd out in tests/dispatch_queue_tests.c because it calls
+# dispatch_stop_repeated_f, which is not yet implemented in
+# src/dispatch_queue.c. Enabling the suite is feature work tracked
+# separately, not part of this split.
+freertos_add_embunit_test(NAME dispatch_queue        SUITE_FN dispatch_queue_get_tests)
+freertos_add_embunit_test(NAME asyncio               SUITE_FN asyncio_get_tests)
+freertos_add_embunit_test(NAME state_event_loop      SUITE_FN state_event_loop_get_tests)

--- a/tests/freertos/GCC_ARM_CM7/main.c
+++ b/tests/freertos/GCC_ARM_CM7/main.c
@@ -8,6 +8,26 @@
 extern void uart0_init(void);
 extern void semihost_exit(int code) __attribute__((noreturn));
 
+/* Stringify the suite accessor selected at compile time
+ * (-DCUTILS_EMBTEST_SUITE=<fn>) for the per-suite runner's label. */
+#define EMBTEST_STR_(s) #s
+#define EMBTEST_STR(s) EMBTEST_STR_(s)
+
+#define RUNNER_STACK_SIZE 2048
+
+static void run_suite(const char *name, TestRef (*get_tests)(void)) {
+  printf("\n[%s] ", name);
+  TestRunner_runTest(get_tests());
+}
+
+#ifndef CUTILS_EMBTEST_SUITE
+/* ---------------------------------------------------------------------------
+ * Aggregate runner: every suite in one QEMU boot. Built when
+ * CUTILS_EMBTEST_SUITE is undefined (the embtest_runner target, opt-in via
+ * CUTILS_FREERTOS_AGGREGATE_RUNNER). Kept for fast "run everything" smoke
+ * tests — it boots QEMU once instead of N times.
+ * ------------------------------------------------------------------------- */
+
 /* Forward declarations — every suite's TestRef accessor */
 extern TestRef klist_get_tests(void);
 extern TestRef mem_ring_buffer_get_tests(void);
@@ -25,13 +45,6 @@ extern TestRef accumulator_get_tests(void);
 extern TestRef dispatch_queue_get_tests(void);
 extern TestRef asyncio_get_tests(void);
 extern TestRef state_event_loop_get_tests(void);
-
-#define RUNNER_STACK_SIZE 2048
-
-static void run_suite(const char *name, TestRef (*get_tests)(void)) {
-  printf("\n[%s] ", name);
-  TestRunner_runTest(get_tests());
-}
 
 static void runner_task(void *arg) {
   (void)arg;
@@ -55,6 +68,25 @@ static void runner_task(void *arg) {
   TestRunner_end();
   semihost_exit(TestRunner_failureCount() ? 1 : 0);
 }
+#else
+/* ---------------------------------------------------------------------------
+ * Per-suite runner: exactly one suite, selected at compile time via
+ * -DCUTILS_EMBTEST_SUITE=<accessor>. Each embtest_<suite> ELF boots QEMU,
+ * runs that one suite, and semihost_exits with pass/fail — giving ctest
+ * first-class per-suite granularity instead of one aggregate result.
+ * ------------------------------------------------------------------------- */
+
+/* The accessor is injected by the build as a function name token. */
+extern TestRef CUTILS_EMBTEST_SUITE(void);
+
+static void runner_task(void *arg) {
+  (void)arg;
+  TestRunner_start();
+  run_suite(EMBTEST_STR(CUTILS_EMBTEST_SUITE), CUTILS_EMBTEST_SUITE);
+  TestRunner_end();
+  semihost_exit(TestRunner_failureCount() ? 1 : 0);
+}
+#endif
 
 TASK_STATIC_STORE_DECL(runner, RUNNER_STACK_SIZE);
 TASK_STATIC_STORE_DEF(runner);


### PR DESCRIPTION
Closes #34.

Splits the FreeRTOS port's single aggregate `embtest_runner` ctest into one ctest per suite, giving CI first-class per-suite granularity instead of one aggregate pass/fail.

## What changed

All confined to `tests/freertos/GCC_ARM_CM7/`:

- **`embtest_common` OBJECT library** — compiles every `tests/*.c` source + the bare-metal scaffolding (`startup.c`, `retarget.c`) exactly once, with `AGGREGATE_RUNNER` defined (suppressing each suite's hosted `main()`). PUBLIC link deps (`cutils`, `platform_abstraction`, `freertos_kernel`, `embunit`) and includes propagate to every consumer.
- **`main.c` two compile-time modes** — undefined `CUTILS_EMBTEST_SUITE` → aggregate `runner_task` (all suites); `-DCUTILS_EMBTEST_SUITE=<accessor>` → per-suite `runner_task` that runs exactly that suite and `semihost_exit`s with pass/fail. Shared boilerplate (uart0_init, task creation, scheduler, `run_suite`, `TASK_STATIC_STORE`) is common to both.
- **`freertos_add_embunit_test(NAME SUITE_FN [TIMEOUT])`** — builds `embtest_<suite>` (`main.c` + `embtest_common`) with the bare-metal link flags and registers a QEMU ctest with the same `-semihosting` contract (semihost_exit → QEMU exit code). Per-suite `TIMEOUT` defaults to 60s.
- **Opt-in aggregate** — `embtest_runner` kept via `-DCUTILS_FREERTOS_AGGREGATE_RUNNER=ON` (default OFF) for fast one-boot smoke runs.

Thanks to `-ffunction-sections` + `--gc-sections` (already in the toolchain), each per-suite ELF carries only its own suite + shared bare-metal: **16–46 KB text vs the 89 KB aggregate**. Suites compile once; `--gc-sections` strips the rest per link.

## On item #6 (the orphaned `dispatch_queue_timer_get_tests`)

Investigated and **excluded** rather than wired in. The suite is `#if 0`'d out in `tests/dispatch_queue_tests.c` because it calls `dispatch_stop_repeated_f`, which is **not implemented** in `src/dispatch_queue.c` (the rest of the timer API — `dispatch_after_f`, `dispatch_start_repeated_f` — is). Enabling the suite is real feature work (implementing `dispatch_stop_repeated_f` + the repeated-dispatch teardown), tracked separately from this split. Documented inline in the CMakeLists.

## Verification

| Check | Result |
|---|---|
| `ctest -N` (freertos-debug) | 16 per-suite tests |
| `ctest` sequential | 16/16 pass, ~1.4s |
| `ctest -j16` parallel | 16/16 pass, ~1.0s |
| `-j16` stress (5 runs) | 5/5 clean — no QEMU contention, no `RESOURCE_LOCKS` needed |
| Aggregate opt-in (`CUTILS_FREERTOS_AGGREGATE_RUNNER=ON`) | builds + runs `embtest_runner`, 89 KB / 1.24s (identical to master) |
| Hosted c11 | 10/10 (unchanged) |
| Hosted pthread | 10/10 (unchanged) |

Per-suite outcomes match the old aggregate (same source, same compile defines — the `os_task`/`queue_ts_queue` skip-stubs compile exactly as before since `RTOS_TASK_IMPLEMENTED`/`CUTILS_TASK_USES_THRD_CREATE` remain undefined on this target; that's pre-existing and out of scope here).

## Refs

- #34 — this ticket.
- `cmake/EmbUnitTest.cmake` (`package_add_embunit_test`) — the hosted per-suite model this mirrors.
- `cmake/arm-none-eabi.cmake` — the `-ffunction-sections`/`--gc-sections` + `CMAKE_SIZE` the design relies on.